### PR TITLE
Bugfix 6008/fix spacing problem in T4T

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.3",
+  "version": "0.15.4-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.4-beta",
+  "version": "0.15.4-beta.1",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.3",
+  "version": "0.15.4-beta",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/src/ScripturePane/helpers/__test__/__snapshots__/verseHelpers.test.js.snap
+++ b/src/ScripturePane/helpers/__test__/__snapshots__/verseHelpers.test.js.snap
@@ -421,8 +421,7 @@ Array [
     </span>
   </span>,
   <span>
-    .
-
+    . 
   </span>,
 ]
 `;
@@ -743,8 +742,7 @@ Array [
     </span>
   </span>,
   <span>
-    .
-
+    . 
   </span>,
 ]
 `;
@@ -752,7 +750,7 @@ Array [
 exports[`verseHelpers.verseArray should succeed with jhn-6-21-en-t4t 1`] = `
 Array [
   <span>
-    We were glad to take him into the boat. As soon as 
+    We were glad to take him into the boat. As soon as 
   </span>,
   <span
     style={
@@ -767,7 +765,7 @@ Array [
     we
   </span>,
   <span>
-    did that, the boat reached the shore where 
+    did that, the boat reached the shore where 
   </span>,
   <span
     style={
@@ -782,8 +780,7 @@ Array [
     we
   </span>,
   <span>
-    were going!
-
+    were going! 
   </span>,
 ]
 `;
@@ -1293,7 +1290,6 @@ Array [
     }
   >
     
-
   </span>,
 ]
 `;
@@ -1897,8 +1893,7 @@ Array [
      
   </span>,
   <span>
-    and,
-
+    and, 
   </span>,
   <span
     style={
@@ -2300,7 +2295,6 @@ Array [
   </span>,
   <span>
     
-
   </span>,
 ]
 `;

--- a/src/ScripturePane/helpers/__test__/__snapshots__/verseHelpers.test.js.snap
+++ b/src/ScripturePane/helpers/__test__/__snapshots__/verseHelpers.test.js.snap
@@ -749,6 +749,45 @@ Array [
 ]
 `;
 
+exports[`verseHelpers.verseArray should succeed with jhn-6-21-en-t4t 1`] = `
+Array [
+  <span>
+    We were glad to take him into the boat. As soon as 
+  </span>,
+  <span
+    style={
+      Object {
+        "backgroundColor": "transparent",
+      }
+    }
+  >
+     
+  </span>,
+  <span>
+    we
+  </span>,
+  <span>
+    did that, the boat reached the shore where 
+  </span>,
+  <span
+    style={
+      Object {
+        "backgroundColor": "transparent",
+      }
+    }
+  >
+     
+  </span>,
+  <span>
+    we
+  </span>,
+  <span>
+    were going!
+
+  </span>,
+]
+`;
+
 exports[`verseHelpers.verseArray should succeed with luke-22-30.ult 1`] = `
 Array [
   <span>

--- a/src/ScripturePane/helpers/__test__/__snapshots__/verseHelpers.test.js.snap
+++ b/src/ScripturePane/helpers/__test__/__snapshots__/verseHelpers.test.js.snap
@@ -765,7 +765,7 @@ Array [
     we
   </span>,
   <span>
-    did that, the boat reached the shore where 
+     did that, the boat reached the shore where 
   </span>,
   <span
     style={
@@ -780,7 +780,7 @@ Array [
     we
   </span>,
   <span>
-    were going! 
+     were going! 
   </span>,
 ]
 `;

--- a/src/ScripturePane/helpers/__test__/__snapshots__/verseHelpers.test.js.snap
+++ b/src/ScripturePane/helpers/__test__/__snapshots__/verseHelpers.test.js.snap
@@ -752,29 +752,11 @@ Array [
   <span>
     We were glad to take him into the boat. As soon as 
   </span>,
-  <span
-    style={
-      Object {
-        "backgroundColor": "transparent",
-      }
-    }
-  >
-     
-  </span>,
   <span>
     we
   </span>,
   <span>
      did that, the boat reached the shore where 
-  </span>,
-  <span
-    style={
-      Object {
-        "backgroundColor": "transparent",
-      }
-    }
-  >
-     
   </span>,
   <span>
     we

--- a/src/ScripturePane/helpers/__test__/fixtures/jhn-6-21-en-t4t.json
+++ b/src/ScripturePane/helpers/__test__/fixtures/jhn-6-21-en-t4t.json
@@ -1,0 +1,29 @@
+[
+  {
+    "type": "text",
+    "text": "We were glad to take him into the boat. As soon as "
+  },
+  {
+    "tag": "add",
+    "text": "we",
+    "endTag": "add*"
+  },
+  {
+    "type": "text",
+    "text": " did that, the boat reached the shore where "
+  },
+  {
+    "tag": "add",
+    "text": "we",
+    "endTag": "add*"
+  },
+  {
+    "type": "text",
+    "text": " were going!\n"
+  },
+  {
+    "tag": "p",
+    "nextChar": "\n",
+    "type": "paragraph"
+  }
+]

--- a/src/ScripturePane/helpers/__test__/verseHelpers.test.js
+++ b/src/ScripturePane/helpers/__test__/verseHelpers.test.js
@@ -54,6 +54,9 @@ describe('verseHelpers.verseArray', () => {
     };
     generateTest('luke-22-30.ult', 'ult', contextId);
   });
+  it('should succeed with jhn-6-21-en-t4t', () => {
+    generateTest('jhn-6-21-en-t4t', 't4t');
+  });
 });
 
 //

--- a/src/ScripturePane/helpers/usfmHelpers.js
+++ b/src/ScripturePane/helpers/usfmHelpers.js
@@ -10,7 +10,7 @@ export const removeMarker = (verseText) => {
   const trimmed = verseText.trimLeft();
   const offset = verseText.indexOf(trimmed);
 
-  if (offset > 0) { // see if we need to preserve leading white space
+  if (offset > 0) { // see if we need to restore leading white space
     text = verseText.substr(0, offset) + text; // restore original leading white space
   }
   return text;

--- a/src/ScripturePane/helpers/usfmHelpers.js
+++ b/src/ScripturePane/helpers/usfmHelpers.js
@@ -5,6 +5,15 @@ import usfmjs from 'usfm-js';
  * @param {String} verseText - The string to remove markers from
  * @return {String}
  */
-export const removeMarker = (verseText) =>
-  usfmjs.removeMarker(verseText);
+export const removeMarker = (verseText) => {
+  let text = usfmjs.removeMarker(verseText);
+  const trimmed = verseText.trimLeft();
+  const offset = verseText.indexOf(trimmed);
+
+  if (offset > 0) { // see if we need to preserve leading white space
+    text = verseText.substr(0, offset) + text; // restore original leading white space
+  }
+  return text;
+};
+
 

--- a/src/ScripturePane/helpers/verseHelpers.js
+++ b/src/ScripturePane/helpers/verseHelpers.js
@@ -150,7 +150,8 @@ export function verseArray(verseText = [], bibleId, contextId, getLexiconData, s
         wordSpacing = nestedMilestone.nestedWordSpacing;
       } else if (word.text) { // if not word, show punctuation, etc. but not clickable
         let text = word.text;
-        text = text.replace(/^\s|\s$/g, '\u00A0'); // replace with no-break space
+        text = text.replace(/^\s/, '\u00A0'); // replace leading space with no-break space
+        text = text.replace(/\s$/, '\u00A0'); // replace trailing space with no-break space
 
         if (word.tag || isIsolatedLeftQuote(text)) { // if this was not just simple text marker, need to add whitespace
           highlightHelpers.addSpace(verseSpan);

--- a/src/ScripturePane/helpers/verseHelpers.js
+++ b/src/ScripturePane/helpers/verseHelpers.js
@@ -150,7 +150,7 @@ export function verseArray(verseText = [], bibleId, contextId, getLexiconData, s
         wordSpacing = nestedMilestone.nestedWordSpacing;
       } else if (word.text) { // if not word, show punctuation, etc. but not clickable
         let text = word.text;
-        text = text.replace(/\s/g, '&nbsp;');
+        text = text.replace(/^\s|\s$/g, '\u00A0'); // replace with no-break space
 
         if (word.tag || isIsolatedLeftQuote(text)) { // if this was not just simple text marker, need to add whitespace
           highlightHelpers.addSpace(verseSpan);

--- a/src/ScripturePane/helpers/verseHelpers.js
+++ b/src/ScripturePane/helpers/verseHelpers.js
@@ -151,11 +151,10 @@ export function verseArray(verseText = [], bibleId, contextId, getLexiconData, s
       } else if (word.text) { // if not word, show punctuation, etc. but not clickable
         let text = word.text;
         text = text.replace(/^\s/, '\u00A0'); // replace leading space with no-break space
-        console.log("leading = " + text.charCodeAt(0));
         text = text.replace(/\s$/, '\u00A0'); // replace trailing space with no-break space
-        console.log("trailing = " + text.charCodeAt(text.length - 1));
+        const isUsfmTagNotSpan = word.tag && !word.endTag; // see if USFM tag does not have a matching end tag.
 
-        if (word.tag || isIsolatedLeftQuote(text)) { // if this was not just simple text marker, need to add whitespace
+        if (isUsfmTagNotSpan || isIsolatedLeftQuote(text)) { // if this was not just simple text marker, need to add whitespace
           highlightHelpers.addSpace(verseSpan);
         }
         wordSpacing = punctuationWordSpacing(word); // spacing before words

--- a/src/ScripturePane/helpers/verseHelpers.js
+++ b/src/ScripturePane/helpers/verseHelpers.js
@@ -151,7 +151,9 @@ export function verseArray(verseText = [], bibleId, contextId, getLexiconData, s
       } else if (word.text) { // if not word, show punctuation, etc. but not clickable
         let text = word.text;
         text = text.replace(/^\s/, '\u00A0'); // replace leading space with no-break space
+        console.log("leading = " + text.charCodeAt(0));
         text = text.replace(/\s$/, '\u00A0'); // replace trailing space with no-break space
+        console.log("trailing = " + text.charCodeAt(text.length - 1));
 
         if (word.tag || isIsolatedLeftQuote(text)) { // if this was not just simple text marker, need to add whitespace
           highlightHelpers.addSpace(verseSpan);

--- a/src/ScripturePane/helpers/verseHelpers.js
+++ b/src/ScripturePane/helpers/verseHelpers.js
@@ -149,7 +149,8 @@ export function verseArray(verseText = [], bibleId, contextId, getLexiconData, s
         previousWord = nestedMilestone.nestedPreviousWord;
         wordSpacing = nestedMilestone.nestedWordSpacing;
       } else if (word.text) { // if not word, show punctuation, etc. but not clickable
-        const text = word.text;
+        let text = word.text;
+        text = text.replace(/\s/g, '&nbsp;');
 
         if (word.tag || isIsolatedLeftQuote(text)) { // if this was not just simple text marker, need to add whitespace
           highlightHelpers.addSpace(verseSpan);

--- a/src/VerseCheck/helpers/selectionHelpers.js
+++ b/src/VerseCheck/helpers/selectionHelpers.js
@@ -1,4 +1,4 @@
-import isEqual from 'deep-equal';
+import xRegExp from 'xregexp';
 import _ from 'lodash';
 // helpers
 import * as stringHelpers from './stringHelpers';
@@ -158,6 +158,121 @@ export const rangesToSelections = (string, ranges) => {
   });
   return selections;
 };
+
+/**
+ * after text has been trimmed, need to update occurrence and occurrences since they may have changed
+ * @param {String} string - verse string
+ * @param {Object} selection - current selection to update
+ * @param {String} trimmedText - new selection.text after trimming
+ */
+function updateTrimmedTextOccurence(string, selection, trimmedText) {
+  let originalRanges = selectionsToRanges(string, [selection]);
+
+  if (originalRanges) {
+    const offset = selection.text.indexOf(trimmedText); // get offset of trimmed from non-trimmed
+    const originalRange = originalRanges[0];
+    const newStartPosition = originalRange[0] + offset;
+    let occurrence = selection.occurrence;
+    const maxOccurrences = stringHelpers.occurrencesInString(string, trimmedText) + 1; // when to stop searching
+    let ranges = [];
+    let reachedEnd = false;
+
+    do { // repeatedly try new occurrence values until it matches the trimmed text position or we go out of bounds
+      const newSelection = [{
+        ...selection,
+        occurrence,
+        text: trimmedText,
+      }];
+      ranges = selectionsToRanges(string, newSelection);
+
+      if (ranges) {
+        const range = ranges[0];
+
+        if (range[0] === newStartPosition) { // if selection for this occurrence is at correct position, we use it
+          const optimizedSelections = rangesToSelections(string, ranges); // clean up occurrences
+
+          if (optimizedSelections) { // if found, we use updated values for occurrence(s)
+            selection.occurrence = optimizedSelections[0].occurrence;
+            selection.occurrences = optimizedSelections[0].occurrences;
+          }
+          ranges = null; // done searching
+        } else {
+          occurrence++;
+          reachedEnd = (occurrence >= maxOccurrences); // likely failed because original selection had invalid occurrence
+        }
+      }
+    } while (!reachedEnd && ranges);
+  }
+}
+
+/**
+ * trim various unicode spaces from leading and trailing edges
+ * @param {string} text - string to trim
+ * @return {string} trimmed text
+ */
+export function unicodeTrim(text) {
+  let match;
+
+  do {
+    // remove leading or trailing unicode whitespace characters as well as:
+    //    const ZERO_WIDTH_SPACE = '\u200B';
+    //    const ZERO_WIDTH_JOINER = '\u2060';
+    const regex = xRegExp(/^[\s\u200B\u2060]+|[\s\u200B\u2060]+$/gu);
+    match = regex.exec(text);
+
+    if (match) {
+      const atStart = match.index === 0;
+
+      if (atStart) {
+        const whiteSpaceLen = match[0].length;
+        text = text.substr(whiteSpaceLen);
+      } else {
+        text = text.substr(0, match.index);
+      }
+    }
+  } while (match);
+
+  return text;
+}
+
+/**
+ * join contiguous ranges (of selections) and return new ranges array
+ * @param {string} text - verse text
+ * @param {Array} ranges
+ * @return {Array}
+ */
+export function joinContiguousRanges(text, ranges) {
+  let outputRanges = ranges;
+
+  if (ranges) {
+    outputRanges = [];
+
+    for (let i = 0, l = ranges.length; i < l; i++) {
+      let range = ranges[i];
+
+      if (i >= 1) { // skip over first range
+        const lastPos = outputRanges.length - 1;
+        const lastRange = outputRanges[lastPos];
+        const gapStart = lastRange[1] + 1;
+        const charactersBetween = range[0] - gapStart;
+        let inBetween = text.substr(gapStart, charactersBetween);
+        inBetween = unicodeTrim(inBetween);
+
+        if (!inBetween.length) { // if only white space
+          lastRange[1] = range[1]; // join this range with previous range
+          range = null;
+        }
+      }
+
+      if (range) {
+        outputRanges.push(range);
+      }
+    }
+  }
+
+  return outputRanges;
+}
+
 /**
  * @description - This abstracts complex handling of selections such as order, deduping, concatenating, overlapping ranges
  * @param {string} string - the text selections are found in
@@ -167,19 +282,26 @@ export const rangesToSelections = (string, ranges) => {
 export const optimizeSelections = (string, selections) => {
   let optimizedSelections; // return
 
-  // filter out the random clicks from the UI
+  // filter out empty selections and trim whitespace
   selections = selections.filter( selection => {
-    const blankSelection = {
-      text: '', occurrence: 1, occurrences: 0,
-    };
-    return !isEqual(selection, blankSelection);
+    const selectedText = selection.text;
+    const trimmedText = unicodeTrim(selectedText);
+    const whiteSpaceSelected = !trimmedText.length;
+
+    if (!whiteSpaceSelected && (trimmedText !== selectedText)) { // if whitespace removed, update selection text
+      updateTrimmedTextOccurence(string, selection, trimmedText);
+      selection.text = trimmedText;
+    }
+    return !whiteSpaceSelected;
   });
 
-  var ranges = selectionsToRanges(string, selections); // get char ranges of each selection
+  let ranges = selectionsToRanges(string, selections); // get char ranges of each selection
   ranges = optimizeRanges(ranges); // optimize the ranges
+  ranges = joinContiguousRanges(string, ranges);
   optimizedSelections = rangesToSelections(string, ranges); // convert optimized ranges into selections
   return optimizedSelections;
 };
+
 /**
  * @description - Removes a selection if found in the array of selections
  * @param {Object} selection - the selection to remove
@@ -195,8 +317,9 @@ export const removeSelectionFromSelections = (selection, selections, string) => 
   selections = optimizeSelections(string, selections);
   return selections;
 };
+
 /**
- * @description - Removes a selection if found in the array of selections
+ * @description - Adds a selection if found in the array of selections
  * @param {Object} selection - the selection to remove
  * @param {Array}  selections - array of selection objects [Obj,...]
  * @param {string} string - the text selections are found in


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix problem that spaces in html are not always shown by replacing leading and trailing spaces with no-break-space.
- fix problem with displaying in HTML: USFM that has an end marker.

#### Please include detailed Test instructions for your pull request:
- use test build attached below.
- update english resources to get the t4t bible.
- open a John project and launch WA tool
- navigate to John 6:4
- add the t4t (translation for translators) to the scripture pane and make sure the issue in https://github.com/unfoldingword/translationcore/issues/6008 is fixed.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/238)
<!-- Reviewable:end -->
