### PR TITLE
Bugfix 6008/Fix whitespace rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.5-beta",
+  "version": "0.15.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.4",
+  "version": "0.15.5-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.4",
+  "version": "0.15.5-beta",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.5-beta",
+  "version": "0.15.5",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/src/ScripturePane/helpers/__test__/__snapshots__/verseHelpers.test.js.snap
+++ b/src/ScripturePane/helpers/__test__/__snapshots__/verseHelpers.test.js.snap
@@ -421,7 +421,16 @@ Array [
     </span>
   </span>,
   <span>
-    . 
+    .
+  </span>,
+  <span
+    style={
+      Object {
+        "backgroundColor": "transparent",
+      }
+    }
+  >
+     
   </span>,
 ]
 `;
@@ -742,7 +751,16 @@ Array [
     </span>
   </span>,
   <span>
-    . 
+    .
+  </span>,
+  <span
+    style={
+      Object {
+        "backgroundColor": "transparent",
+      }
+    }
+  >
+     
   </span>,
 ]
 `;
@@ -750,19 +768,64 @@ Array [
 exports[`verseHelpers.verseArray should succeed with jhn-6-21-en-t4t 1`] = `
 Array [
   <span>
-    We were glad to take him into the boat. As soon as 
+    We were glad to take him into the boat. As soon as
+  </span>,
+  <span
+    style={
+      Object {
+        "backgroundColor": "transparent",
+      }
+    }
+  >
+     
   </span>,
   <span>
     we
   </span>,
+  <span
+    style={
+      Object {
+        "backgroundColor": "transparent",
+      }
+    }
+  >
+     
+  </span>,
   <span>
-     did that, the boat reached the shore where 
+    did that, the boat reached the shore where
+  </span>,
+  <span
+    style={
+      Object {
+        "backgroundColor": "transparent",
+      }
+    }
+  >
+     
   </span>,
   <span>
     we
   </span>,
+  <span
+    style={
+      Object {
+        "backgroundColor": "transparent",
+      }
+    }
+  >
+     
+  </span>,
   <span>
-     were going! 
+    were going!
+  </span>,
+  <span
+    style={
+      Object {
+        "backgroundColor": "transparent",
+      }
+    }
+  >
+     
   </span>,
 ]
 `;
@@ -1267,11 +1330,29 @@ Array [
   <span
     style={
       Object {
+        "backgroundColor": "transparent",
+      }
+    }
+  >
+     
+  </span>,
+  <span
+    style={
+      Object {
         "backgroundColor": "var(--highlight-color)",
       }
     }
   >
     
+  </span>,
+  <span
+    style={
+      Object {
+        "backgroundColor": "transparent",
+      }
+    }
+  >
+     
   </span>,
 ]
 `;
@@ -1875,7 +1956,16 @@ Array [
      
   </span>,
   <span>
-    and, 
+    and,
+  </span>,
+  <span
+    style={
+      Object {
+        "backgroundColor": "transparent",
+      }
+    }
+  >
+     
   </span>,
   <span
     style={
@@ -2274,6 +2364,15 @@ Array [
   </span>,
   <span>
     .'"
+  </span>,
+  <span
+    style={
+      Object {
+        "backgroundColor": "transparent",
+      }
+    }
+  >
+     
   </span>,
   <span>
     

--- a/src/ScripturePane/helpers/usfmHelpers.js
+++ b/src/ScripturePane/helpers/usfmHelpers.js
@@ -1,5 +1,9 @@
 import usfmjs from 'usfm-js';
 
+// consts
+const leadingSpacesRegex = new RegExp(/^\s/);
+const trailingSpacesRegex = new RegExp(/\s$/);
+
 /**
  * Method to filter usfm markers from a string
  * @param {String} verseText - The string to remove markers from
@@ -16,4 +20,22 @@ export const removeMarker = (verseText) => {
   return text;
 };
 
+/**
+ * returns true if text has leading white space
+ * @param {String} text
+ * @return {boolean}
+ */
+export const hasLeadingSpace = (text) => {
+  const hasSpace = leadingSpacesRegex.test(text);
+  return hasSpace;
+};
 
+/**
+ * returns true if text has trailing white space
+ * @param {String} text
+ * @return {boolean}
+ */
+export const hasTrailingSpace = (text) => {
+  const hasSpace = trailingSpacesRegex.test(text);
+  return hasSpace;
+};


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- removed non-break space which caused rendering problem.  Now using our standard space span.

#### Please include detailed Test instructions for your pull request:
- can use test build attached below.
- update english resources to get the t4t bible.
- open a John project and launch WA tool
- add the t4t (translation for translators) to the scripture pane
- navigate to John 6:21  and make sure the original issue in unfoldingWord/translationCore#6008 is fixed in t4t.
- navigate to John 18:38 and make sure `"How` is rendered correctly without a space after `"`
- navigate to John 19:14 and make sure it is rendered like screenshot in x2.1.0 (605b3a6) 


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/241)
<!-- Reviewable:end -->
