### PR TITLE
Bugfix 5705/On the dialog to add resources to the scripture pane, localize close and load buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.6-beta",
+  "version": "0.15.6-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.5",
+  "version": "0.15.6-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.6-beta.3",
+  "version": "0.15.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.5",
+  "version": "0.15.6-beta",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.6-beta.3",
+  "version": "0.15.6",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.6-beta",
+  "version": "0.15.6-beta.3",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/src/ScripturePane/AddPaneModal/index.js
+++ b/src/ScripturePane/AddPaneModal/index.js
@@ -125,12 +125,12 @@ const AddPaneModal = ({
       </DialogContent>
       <DialogActions disableActionSpacing style={styles.dialogActions}>
         <button className="btn-second" onClick={onHide}>
-          Close
+          {translate('close')}
         </button>
         {
           selectedPane &&
           <button className="btn-prime" onClick={addNewBibleResource}>
-            Load
+            {translate('load')}
           </button>
         }
       </DialogActions>


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- On the dialog to add resources to the scripture pane, localize close and load buttons

#### Please include detailed Test instructions for your pull request:
- use test build attached below.
- for each tool: wa, tw, tn:
  - launch tool
  - make sure locale is set to English
  - on Scripture pane click on add resources icon.
  - from drop down, select a resource
  - on dialog, should see valid text on Close and Load buttons
  - click Close button
  - set locale to language other than English
  - on Scripture pane click on add resources icon.
  - from drop down, select a resource
  - on dialog, should see valid text on Close button (left).  Load button should say "missing translation key..." since we do not yet have translation for the button text.
  - click Close button (left)
  - change locale to English

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/242)
<!-- Reviewable:end -->
