### PR TITLE
Bugfix 6025/fix to localize "No selection Needed"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.7-beta",
+  "version": "0.15.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.6",
+  "version": "0.15.7-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.6",
+  "version": "0.15.7-beta",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.7-beta",
+  "version": "0.15.7-beta.2",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.7-beta.2",
+  "version": "0.15.7",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/src/VerseCheck/ActionsArea/index.js
+++ b/src/VerseCheck/ActionsArea/index.js
@@ -161,14 +161,14 @@ const ConfirmSelectionArea = ({
             }}
           />
         }
-        label={translate('nothing_to_select')}
+        label={translate('no_selection_needed')}
         classes={{
           root: classes.formControl,
           label: classes.label,
         }}
       />
       <div
-        data-tip={translate('nothing_to_select_description')}
+        data-tip={translate('no_selection_needed_description')}
         data-place="top"
         data-effect="float"
         data-type="dark"

--- a/src/VerseCheck/ActionsArea/index.js
+++ b/src/VerseCheck/ActionsArea/index.js
@@ -161,7 +161,7 @@ const ConfirmSelectionArea = ({
             }}
           />
         }
-        label="No selection needed"
+        label={translate('nothing_to_select')}
         classes={{
           root: classes.formControl,
           label: classes.label,

--- a/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
+++ b/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
@@ -783,7 +783,7 @@ exports[`VerseCheck component: Integrated View test 1`] = `
             <span
               className="MuiTypography-root-40 MuiTypography-body1-49 MuiFormControlLabel-label-11 ActionsArea-label-2"
             >
-              nothing_to_select
+              no_selection_needed
             </span>
           </label>
           <div
@@ -791,7 +791,7 @@ exports[`VerseCheck component: Integrated View test 1`] = `
             data-delay-hide="100"
             data-effect="float"
             data-place="top"
-            data-tip="nothing_to_select_description"
+            data-tip="no_selection_needed_description"
             data-type="dark"
             style={
               Object {
@@ -1455,7 +1455,7 @@ exports[`VerseCheck component: Integrated View test with invalidated 1`] = `
             <span
               className="MuiTypography-root-40 MuiTypography-body1-49 MuiFormControlLabel-label-11 ActionsArea-label-2"
             >
-              nothing_to_select
+              no_selection_needed
             </span>
           </label>
           <div
@@ -1463,7 +1463,7 @@ exports[`VerseCheck component: Integrated View test with invalidated 1`] = `
             data-delay-hide="100"
             data-effect="float"
             data-place="top"
-            data-tip="nothing_to_select_description"
+            data-tip="no_selection_needed_description"
             data-type="dark"
             style={
               Object {
@@ -1789,7 +1789,7 @@ exports[`VerseCheck component: Integrated View test with verseEdit 1`] = `
             <span
               className="MuiTypography-root-40 MuiTypography-body1-49 MuiFormControlLabel-label-11 ActionsArea-label-2"
             >
-              nothing_to_select
+              no_selection_needed
             </span>
           </label>
           <div
@@ -1797,7 +1797,7 @@ exports[`VerseCheck component: Integrated View test with verseEdit 1`] = `
             data-delay-hide="100"
             data-effect="float"
             data-place="top"
-            data-tip="nothing_to_select_description"
+            data-tip="no_selection_needed_description"
             data-type="dark"
             style={
               Object {

--- a/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
+++ b/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
@@ -783,7 +783,7 @@ exports[`VerseCheck component: Integrated View test 1`] = `
             <span
               className="MuiTypography-root-40 MuiTypography-body1-49 MuiFormControlLabel-label-11 ActionsArea-label-2"
             >
-              No selection needed
+              nothing_to_select
             </span>
           </label>
           <div
@@ -1455,7 +1455,7 @@ exports[`VerseCheck component: Integrated View test with invalidated 1`] = `
             <span
               className="MuiTypography-root-40 MuiTypography-body1-49 MuiFormControlLabel-label-11 ActionsArea-label-2"
             >
-              No selection needed
+              nothing_to_select
             </span>
           </label>
           <div
@@ -1789,7 +1789,7 @@ exports[`VerseCheck component: Integrated View test with verseEdit 1`] = `
             <span
               className="MuiTypography-root-40 MuiTypography-body1-49 MuiFormControlLabel-label-11 ActionsArea-label-2"
             >
-              No selection needed
+              nothing_to_select
             </span>
           </label>
           <div


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- localize "No selection Needed" string
- fix helps string to use correct key.

#### Please include detailed Test instructions for your pull request:
- use test build below.  Make sure that "No selection Needed" checkbox is localized in tW and tN.  Should see localized strings for Spanish and Hindi.

![Screen Shot 2019-11-25 at 8 31 10 AM](https://user-images.githubusercontent.com/14238574/69545074-06495380-0f5f-11ea-9f77-e797d39d8015.png)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/244)
<!-- Reviewable:end -->
