### PR TITLE
Bugfix 6025/Fix hover for "No selection Needed" checkbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.7",
+  "version": "0.15.7-beta",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.7-beta",
+  "version": "0.15.8",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/src/VerseCheck/ActionsArea/index.js
+++ b/src/VerseCheck/ActionsArea/index.js
@@ -168,7 +168,7 @@ const ConfirmSelectionArea = ({
         }}
       />
       <div
-        data-tip={translate('no_selection_needed_description')}
+        data-tip={translate('nothing_to_select_description')}
         data-place="top"
         data-effect="float"
         data-type="dark"

--- a/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
+++ b/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
@@ -791,7 +791,7 @@ exports[`VerseCheck component: Integrated View test 1`] = `
             data-delay-hide="100"
             data-effect="float"
             data-place="top"
-            data-tip="no_selection_needed_description"
+            data-tip="nothing_to_select_description"
             data-type="dark"
             style={
               Object {
@@ -1463,7 +1463,7 @@ exports[`VerseCheck component: Integrated View test with invalidated 1`] = `
             data-delay-hide="100"
             data-effect="float"
             data-place="top"
-            data-tip="no_selection_needed_description"
+            data-tip="nothing_to_select_description"
             data-type="dark"
             style={
               Object {
@@ -1797,7 +1797,7 @@ exports[`VerseCheck component: Integrated View test with verseEdit 1`] = `
             data-delay-hide="100"
             data-effect="float"
             data-place="top"
-            data-tip="no_selection_needed_description"
+            data-tip="nothing_to_select_description"
             data-type="dark"
             style={
               Object {


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- revert locale key change back to `nothing_to_select_description`  to Fix hover for "No selection Needed" checkbox

#### Please include detailed Test instructions for your pull request:
- use test build below.  Make sure that "No selection Needed" checkbox is localized in tW and tN.  Should see localized strings for the checkbox and hover in Spanish and Hindi.

![Screen Shot 2019-11-25 at 10 41 09 AM](https://user-images.githubusercontent.com/14238574/69554852-65639400-0f70-11ea-827f-9df7379e20a8.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/245)
<!-- Reviewable:end -->

