### PR TITLE
Feature 6600/Add Markdown support for occurrence notes in tN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.8",
+  "version": "0.15.9-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.8",
+  "version": "0.15.9-beta",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.9-beta",
+  "version": "0.15.9-beta.3",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "0.15.9-beta.3",
+  "version": "0.15.9",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/src/CheckInfoCard/PhraseWithToolTip.js
+++ b/src/CheckInfoCard/PhraseWithToolTip.js
@@ -12,8 +12,8 @@ function PhraseWithToolTip({ phrase, getScriptureFromReference }) {
     const [wholeMatch, referenceText, lang, id, book, chapter, verse] = rcMatch;
     const [preReference, postReference] = phrase.split(wholeMatch);
     const tooltipLabel = getScriptureFromReference(lang, id, book, chapter, verse);
-    return (<div>
-      {preReference}
+    return (<div >
+      <span dangerouslySetInnerHTML={{ __html: preReference }} />
       <span onMouseEnter={() => {
         const { top, left } = getOffset(scriptureRef);
         tooltipRef.style.top = `${top}px`;

--- a/src/CheckInfoCard/PhraseWithToolTip.js
+++ b/src/CheckInfoCard/PhraseWithToolTip.js
@@ -31,7 +31,9 @@ function PhraseWithToolTip({ phrase, getScriptureFromReference }) {
     </div>
     );
   } else {
-    return phrase;
+    return (
+      <div dangerouslySetInnerHTML={{ __html: phrase }} />
+    );
   }
 }
 

--- a/src/CheckInfoCard/__snapshots__/CheckInfoCard.test.js.snap
+++ b/src/CheckInfoCard/__snapshots__/CheckInfoCard.test.js.snap
@@ -19,7 +19,13 @@ exports[`CheckInfoCard renders correctly 1`] = `
     <div
       className="phrase"
     >
-      The term "save" refers to keeping someone from experiencing something bad or harmful. To "be safe" means to be protected from harm or danger.
+      <div
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "The term \\"save\\" refers to keeping someone from experiencing something bad or harmful. To \\"be safe\\" means to be protected from harm or danger.",
+          }
+        }
+      />
     </div>
     <div
       className="linkActive"


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- added html support to PhraseWithTooltip

#### Please include detailed Test instructions for your pull request:
- can test with attached build.  Should support emphasis in tN.  
- open a titus project with GL set to EN and should not see the *** displayed checks (see https://github.com/unfoldingword/translationcore/issues/6600)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/247)
<!-- Reviewable:end -->
