### PR TITLE
Display tA links in the check info ("smurf") card

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/src/CheckInfoCard/CheckInfoCard.js
+++ b/src/CheckInfoCard/CheckInfoCard.js
@@ -10,6 +10,7 @@ const CheckInfoCard = ({
   phrase,
   seeMoreLabel,
   onSeeMoreClick,
+  onLinkClick,
   showSeeMoreButton,
   getScriptureFromReference,
 }) => (
@@ -21,7 +22,7 @@ const CheckInfoCard = ({
     </div>
     <div className="rightSide">
       <div className="phrase">
-        <PhraseWithToolTip getScriptureFromReference={getScriptureFromReference} phrase={phrase} />
+        <PhraseWithToolTip getScriptureFromReference={getScriptureFromReference} phrase={phrase} onClickLink={onLinkClick} />
       </div>
       <div onClick={showSeeMoreButton ? onSeeMoreClick : null} className={showSeeMoreButton ? 'linkActive' : 'linkInactive'}>
         {seeMoreLabel}
@@ -35,6 +36,7 @@ CheckInfoCard.propTypes = {
   title: PropTypes.string,
   seeMoreLabel: PropTypes.string,
   onSeeMoreClick: PropTypes.func,
+  onLinkClick: PropTypes.func,
   showSeeMoreButton: PropTypes.bool,
   getScriptureFromReference: PropTypes.func,
 };

--- a/src/CheckInfoCard/PhraseWithToolTip.js
+++ b/src/CheckInfoCard/PhraseWithToolTip.js
@@ -53,7 +53,7 @@ function PhraseWithToolTip({
     );
   } else {
     return (
-      <div ref={phraseEl} style={{ color: '#abd4fd' }} dangerouslySetInnerHTML={{ __html: marked(phrase) }} />
+      <div ref={phraseEl} style={{ color: '#fff' }} dangerouslySetInnerHTML={{ __html: marked(phrase) }} />
     );
   }
 }

--- a/src/CheckInfoCard/PhraseWithToolTip.js
+++ b/src/CheckInfoCard/PhraseWithToolTip.js
@@ -29,6 +29,7 @@ function PhraseWithToolTip({
   const showTooltip = rcMatch.length > 0;
 
   if (showTooltip) {
+    console.log("rendering smurf phrase with tooltip"); //debug
     const [wholeMatch, referenceText, lang, id, book, chapter, verse] = rcMatch;
     const [preReference, postReference] = phrase.split(wholeMatch);
     const tooltipLabel = getScriptureFromReference(lang, id, book, chapter, verse);
@@ -52,6 +53,7 @@ function PhraseWithToolTip({
     </div>
     );
   } else {
+    console.log("rendering smurf phrase"); // debug
     return (
       <div ref={phraseEl} style={{ color: '#fff' }} dangerouslySetInnerHTML={{ __html: marked(phrase) }} />
     );

--- a/src/CheckInfoCard/PhraseWithToolTip.js
+++ b/src/CheckInfoCard/PhraseWithToolTip.js
@@ -29,7 +29,6 @@ function PhraseWithToolTip({
   const showTooltip = rcMatch.length > 0;
 
   if (showTooltip) {
-    console.log("rendering smurf phrase with tooltip"); //debug
     const [wholeMatch, referenceText, lang, id, book, chapter, verse] = rcMatch;
     const [preReference, postReference] = phrase.split(wholeMatch);
     const tooltipLabel = getScriptureFromReference(lang, id, book, chapter, verse);
@@ -48,12 +47,11 @@ function PhraseWithToolTip({
           textDecoration: 'underline',
         }} ref={(ref) => scriptureRef = ref}>{referenceText}</span>
       </span>
-      {/*  TODO: this needs to be marked() as well */}
+      {/*  TODO: this needs to be marked() as well. But we need a use case to test this. */}
       {postReference}
     </div>
     );
   } else {
-    console.log("rendering smurf phrase"); // debug
     return (
       <div ref={phraseEl} style={{ color: '#fff' }} dangerouslySetInnerHTML={{ __html: marked(phrase) }} />
     );

--- a/src/CheckInfoCard/PhraseWithToolTip.js
+++ b/src/CheckInfoCard/PhraseWithToolTip.js
@@ -1,8 +1,21 @@
 /* eslint-disable no-return-assign */
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
 import { getOffset } from './helpers';
+import marked from 'marked';
 
 function PhraseWithToolTip({ phrase, getScriptureFromReference }) {
+  const phraseEl = useRef(null);
+  useEffect(() => {
+    const anchors = phraseEl.current.getElementsByTagName(`a`);
+    console.log(anchors);
+    for (const a of anchors) {
+      a.onclick = (event) => {
+        event.preventDefault();
+        console.log(`Intercepted link ${a.href}`);
+      }
+    }
+  }, [phrase, phraseEl]);
+
   let scriptureRef;
   let tooltipRef;
   const rcMatch = phrase.match(/\[([^\]]+)\]\s*\(rc:\/\/([\w-]+)\/([\w-]+)\/book\/(\w+)\/(\d+)\/(\d+)\)/) || [];
@@ -27,12 +40,13 @@ function PhraseWithToolTip({ phrase, getScriptureFromReference }) {
           textDecoration: 'underline',
         }} ref={(ref) => scriptureRef = ref}>{referenceText}</span>
       </span>
+      {/*  TODO: this needs to be marked() as well */}
       {postReference}
     </div>
     );
   } else {
     return (
-      <div dangerouslySetInnerHTML={{ __html: phrase }} />
+      <div ref={phraseEl} dangerouslySetInnerHTML={{ __html: marked(phrase) }} />
     );
   }
 }

--- a/src/CheckInfoCard/PhraseWithToolTip.js
+++ b/src/CheckInfoCard/PhraseWithToolTip.js
@@ -1,20 +1,27 @@
 /* eslint-disable no-return-assign */
-import React, {useEffect, useRef} from 'react';
-import { getOffset } from './helpers';
+import React, { useEffect, useRef } from 'react';
 import marked from 'marked';
+import { getOffset } from './helpers';
 
-function PhraseWithToolTip({ phrase, getScriptureFromReference }) {
+function PhraseWithToolTip({
+  phrase, getScriptureFromReference, onClickLink,
+}) {
   const phraseEl = useRef(null);
+
   useEffect(() => {
     const anchors = phraseEl.current.getElementsByTagName(`a`);
-    console.log(anchors);
+
     for (const a of anchors) {
       a.onclick = (event) => {
         event.preventDefault();
-        console.log(`Intercepted link ${a.href}`);
-      }
+
+        if (typeof onClickLink === 'function') {
+          // give the link path and title to the handler.
+          onClickLink(a.href, a.innerHTML);
+        }
+      };
     }
-  }, [phrase, phraseEl]);
+  }, [phrase, phraseEl, onClickLink]);
 
   let scriptureRef;
   let tooltipRef;
@@ -46,7 +53,7 @@ function PhraseWithToolTip({ phrase, getScriptureFromReference }) {
     );
   } else {
     return (
-      <div ref={phraseEl} dangerouslySetInnerHTML={{ __html: marked(phrase) }} />
+      <div ref={phraseEl} style={{ color: '#abd4fd' }} dangerouslySetInnerHTML={{ __html: marked(phrase) }} />
     );
   }
 }

--- a/src/CheckInfoCard/__snapshots__/CheckInfoCard.test.js.snap
+++ b/src/CheckInfoCard/__snapshots__/CheckInfoCard.test.js.snap
@@ -22,7 +22,13 @@ exports[`CheckInfoCard renders correctly 1`] = `
       <div
         dangerouslySetInnerHTML={
           Object {
-            "__html": "The term \\"save\\" refers to keeping someone from experiencing something bad or harmful. To \\"be safe\\" means to be protected from harm or danger.",
+            "__html": "<p>The term &quot;save&quot; refers to keeping someone from experiencing something bad or harmful. To &quot;be safe&quot; means to be protected from harm or danger.</p>
+",
+          }
+        }
+        style={
+          Object {
+            "color": "#fff",
           }
         }
       />

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,5 +31,5 @@ module.exports = {
       },
     ],
   },
-  externals: { 'react': 'commonjs react' },
+  externals: { 'react': 'commonjs react', 'react-dom': 'commonjs react-dom' },
 };


### PR DESCRIPTION
This is related to https://github.com/unfoldingword/translationcore/issues/6351

* Displays clickable tA links.
* Clicks can be handled by adding an `onLinkClick` prop to `CheckInfoCard`

**Other changes**
* Added react-dom to webpack's `externals` so that it can function like a proper peer-dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/254)
<!-- Reviewable:end -->
