### PR TITLE
Fixes null bug in check info card.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "dist/bundle.js",
   "display": "library",

--- a/src/CheckInfoCard/PhraseWithToolTip.js
+++ b/src/CheckInfoCard/PhraseWithToolTip.js
@@ -1,27 +1,38 @@
 /* eslint-disable no-return-assign */
-import React, { useEffect, useRef } from 'react';
+import React, {useEffect, useRef} from 'react';
 import marked from 'marked';
-import { getOffset } from './helpers';
+import {getOffset} from './helpers';
 
-function PhraseWithToolTip({
-  phrase, getScriptureFromReference, onClickLink,
-}) {
-  const phraseEl = useRef(null);
-
+/**
+ * Attaches click listeners to links in the ref's text
+ * @param ref
+ * @param onClick
+ */
+const useLinkEffect = (ref, onClick) => {
   useEffect(() => {
-    const anchors = phraseEl.current.getElementsByTagName(`a`);
+    // find anchors in text
+    const anchors = ref.current ? ref.current.getElementsByTagName(`a`) : [];
 
+    // add click handler
     for (const a of anchors) {
       a.onclick = (event) => {
         event.preventDefault();
 
-        if (typeof onClickLink === 'function') {
+        if (typeof onClick === 'function') {
           // give the link path and title to the handler.
-          onClickLink(a.href, a.innerHTML);
+          onClick(a.href, a.innerHTML);
         }
       };
     }
-  }, [phrase, phraseEl, onClickLink]);
+  }, [ref, onClick]);
+};
+
+function PhraseWithToolTip({phrase, getScriptureFromReference, onClickLink}) {
+  const phraseEl = useRef(null);
+  const toolTippedPhraseEl = useRef(null);
+
+  useLinkEffect(phraseEl, onClickLink);
+  useLinkEffect(toolTippedPhraseEl, onClickLink);
 
   let scriptureRef;
   let tooltipRef;
@@ -32,28 +43,34 @@ function PhraseWithToolTip({
     const [wholeMatch, referenceText, lang, id, book, chapter, verse] = rcMatch;
     const [preReference, postReference] = phrase.split(wholeMatch);
     const tooltipLabel = getScriptureFromReference(lang, id, book, chapter, verse);
-    return (<div >
-      <span dangerouslySetInnerHTML={{ __html: preReference }} />
-      <span onMouseEnter={() => {
-        const { top, left } = getOffset(scriptureRef);
-        tooltipRef.style.top = `${top}px`;
-        tooltipRef.style.left = `${left}px`;
-        tooltipRef.style.width = `${scriptureRef.offsetWidth}px`;
-        tooltipRef.style.height = `${scriptureRef.offsetHeight}px`;
-      }} style={{ position: 'relative' }}>
-        <div ref={(ref) => tooltipRef = ref} aria-label={tooltipLabel} className="hint--top hint--medium" style={{ position: 'fixed' }} />
-        <span style={{
-          whiteSpace: 'nowrap',
-          textDecoration: 'underline',
-        }} ref={(ref) => scriptureRef = ref}>{referenceText}</span>
-      </span>
-      {/*  TODO: this needs to be marked() as well. But we need a use case to test this. */}
-      {postReference}
-    </div>
+    return (
+      <div>
+        <span dangerouslySetInnerHTML={{__html: preReference}}/>
+        <span onMouseEnter={() => {
+          const {top, left} = getOffset(scriptureRef);
+          tooltipRef.style.top = `${top}px`;
+          tooltipRef.style.left = `${left}px`;
+          tooltipRef.style.width = `${scriptureRef.offsetWidth}px`;
+          tooltipRef.style.height = `${scriptureRef.offsetHeight}px`;
+        }} style={{position: 'relative'}}>
+          <div ref={(ref) => tooltipRef = ref}
+               aria-label={tooltipLabel}
+               className="hint--top hint--medium"
+               style={{position: 'fixed'}}/>
+          <span style={{
+            whiteSpace: 'nowrap',
+            textDecoration: 'underline',
+          }} ref={(ref) => scriptureRef = ref}>
+            {referenceText}
+          </span>
+        </span>
+        <span ref={toolTippedPhraseEl} style={{color: '#fff'}}
+              dangerouslySetInnerHTML={{__html: marked(postReference)}}/>
+      </div>
     );
   } else {
     return (
-      <div ref={phraseEl} style={{ color: '#fff' }} dangerouslySetInnerHTML={{ __html: marked(phrase) }} />
+      <div ref={phraseEl} style={{color: '#fff'}} dangerouslySetInnerHTML={{__html: marked(phrase)}}/>
     );
   }
 }

--- a/src/CheckInfoCard/PhraseWithToolTip.js
+++ b/src/CheckInfoCard/PhraseWithToolTip.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-return-assign */
-import React, {useEffect, useRef} from 'react';
+import React, { useEffect, useRef } from 'react';
 import marked from 'marked';
-import {getOffset} from './helpers';
+import { getOffset } from './helpers';
 
 /**
  * Attaches click listeners to links in the ref's text
@@ -27,7 +27,9 @@ const useLinkEffect = (ref, onClick) => {
   }, [ref, onClick]);
 };
 
-function PhraseWithToolTip({phrase, getScriptureFromReference, onClickLink}) {
+function PhraseWithToolTip({
+  phrase, getScriptureFromReference, onClickLink,
+}) {
   const phraseEl = useRef(null);
   const toolTippedPhraseEl = useRef(null);
 
@@ -45,18 +47,18 @@ function PhraseWithToolTip({phrase, getScriptureFromReference, onClickLink}) {
     const tooltipLabel = getScriptureFromReference(lang, id, book, chapter, verse);
     return (
       <div>
-        <span dangerouslySetInnerHTML={{__html: preReference}}/>
+        <span dangerouslySetInnerHTML={{ __html: preReference }}/>
         <span onMouseEnter={() => {
-          const {top, left} = getOffset(scriptureRef);
+          const { top, left } = getOffset(scriptureRef);
           tooltipRef.style.top = `${top}px`;
           tooltipRef.style.left = `${left}px`;
           tooltipRef.style.width = `${scriptureRef.offsetWidth}px`;
           tooltipRef.style.height = `${scriptureRef.offsetHeight}px`;
-        }} style={{position: 'relative'}}>
+        }} style={{ position: 'relative' }}>
           <div ref={(ref) => tooltipRef = ref}
-               aria-label={tooltipLabel}
-               className="hint--top hint--medium"
-               style={{position: 'fixed'}}/>
+            aria-label={tooltipLabel}
+            className="hint--top hint--medium"
+            style={{ position: 'fixed' }}/>
           <span style={{
             whiteSpace: 'nowrap',
             textDecoration: 'underline',
@@ -64,13 +66,13 @@ function PhraseWithToolTip({phrase, getScriptureFromReference, onClickLink}) {
             {referenceText}
           </span>
         </span>
-        <span ref={toolTippedPhraseEl} style={{color: '#fff'}}
-              dangerouslySetInnerHTML={{__html: marked(postReference)}}/>
+        <span ref={toolTippedPhraseEl} style={{ color: '#fff' }}
+          dangerouslySetInnerHTML={{ __html: marked(postReference) }}/>
       </div>
     );
   } else {
     return (
-      <div ref={phraseEl} style={{color: '#fff'}} dangerouslySetInnerHTML={{__html: marked(phrase)}}/>
+      <div ref={phraseEl} style={{ color: '#fff' }} dangerouslySetInnerHTML={{ __html: marked(phrase) }}/>
     );
   }
 }


### PR DESCRIPTION
Related to https://github.com/unfoldingword/translationcore/issues/6858

* Adds null checking
* Adds support for rendering links when there is also a verse tooltip.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/260)
<!-- Reviewable:end -->
