### PR TITLE
Bugfix 6847/fix to show all target words in SP and word bank and better invalidation checking in WA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4539,9 +4539,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
           "dev": true
         },
         "regenerator-runtime": {
@@ -12072,9 +12072,9 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "replace-ext": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
+      "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
       "dev": true
     },
     "request": {
@@ -14029,9 +14029,9 @@
       "dev": true
     },
     "word-aligner": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word-aligner/-/word-aligner-0.3.0.tgz",
-      "integrity": "sha512-e5pvbiX605z5Hz/l0ejdtELepiK40Zkc5XESXSHWaMi0DztQZqaVV2KPhm67JNf0ezAO+o+7kmItkYp4EWhIpg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/word-aligner/-/word-aligner-0.4.0.tgz",
+      "integrity": "sha512-TojJFi0ObcPJWgviFEAWL4av+9M6kqx6+xT17OOsJPOyFCiSsrCJwEiMTLiaWv1jo9mK0r7/u2c4B8r2i2SPvw==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -14041,22 +14041,7 @@
         "path-extra": "^4.2.1",
         "rimraf": "^2.6.2",
         "string-punctuation-tokenizer": "2.0.0",
-        "transform-runtime": "0.0.0",
-        "usfm-js": "2.0.2"
-      },
-      "dependencies": {
-        "usfm-js": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-2.0.2.tgz",
-          "integrity": "sha512-9dykXM14qzp8+hp73xr+qz1lljtDPApUukzD/Md/pB0Dp5sAicl7OJLXhBHbQVmOKigpRS+JexIaa9x+yBWWaw==",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.26.0",
-            "lodash": "^4.17.11",
-            "rimraf": "^2.6.3",
-            "transform-runtime": "0.0.0"
-          }
-        }
+        "transform-runtime": "0.0.0"
       }
     },
     "word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "2.1.0",
+  "version": "2.1.1-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13568,8 +13568,8 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "usfm-js": {
-      "version": "github:unfoldingWord/usfm-js#d2f670accb0a2e698ed3552b8fcc87a14d8b3a1d",
-      "from": "github:unfoldingWord/usfm-js#bugfix-mcleanb-6847",
+      "version": "2.0.4-alpha",
+      "resolved": "github:unfoldingWord/usfm-js#d2f670accb0a2e698ed3552b8fcc87a14d8b3a1d",
       "requires": {
         "lodash.clonedeep": "^4.5.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "2.1.1-alpha",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10157,7 +10157,8 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
     },
     "lodash.escape": {
       "version": "4.0.1",
@@ -13568,8 +13569,10 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "usfm-js": {
-      "version": "2.0.4-alpha",
-      "resolved": "github:unfoldingWord/usfm-js#d2f670accb0a2e698ed3552b8fcc87a14d8b3a1d",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-2.1.0.tgz",
+      "integrity": "sha512-DemzdzAwrVeuzRwnZYOKvAle/U2ZUUf04NQSVDgqZCSFyH7hVhe2/PWC7jT2DKnPMYoa0IxnG3XGbuOPXgZ/oQ==",
+      "dev": true,
       "requires": {
         "lodash.clonedeep": "^4.5.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "2.1.1",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4532,6 +4532,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -4540,12 +4541,14 @@
         "core-js": {
           "version": "2.6.5",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
         }
       }
     },
@@ -10151,6 +10154,11 @@
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
     "lodash.escape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
@@ -12218,6 +12226,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -13302,7 +13311,8 @@
     "transform-runtime": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/transform-runtime/-/transform-runtime-0.0.0.tgz",
-      "integrity": "sha1-5xTZtpIR3ZU3k51Q46pXiMRCuFw="
+      "integrity": "sha1-5xTZtpIR3ZU3k51Q46pXiMRCuFw=",
+      "dev": true
     },
     "trim-right": {
       "version": "1.0.1",
@@ -13558,14 +13568,10 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "usfm-js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-2.0.1.tgz",
-      "integrity": "sha512-tH1+WQI3f9lh02301FWKdbKbz3lbxADs6hFZGchgcrOTmcwV9/aiG3RbSLtfnL4Xn0/DsSHFhf/Tf54iTpoVaA==",
+      "version": "github:unfoldingWord/usfm-js#d2f670accb0a2e698ed3552b8fcc87a14d8b3a1d",
+      "from": "github:unfoldingWord/usfm-js#bugfix-mcleanb-6847",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "lodash": "^4.17.11",
-        "rimraf": "^2.6.3",
-        "transform-runtime": "0.0.0"
+        "lodash.clonedeep": "^4.5.0"
       }
     },
     "util": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "3.0.1-alpha",
+  "version": "3.0.1",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "2.1.1-alpha",
+  "version": "2.1.1",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",
@@ -65,7 +65,8 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "string-punctuation-tokenizer": "^2.0.0",
-    "word-aligner": "^0.3.0"
+    "word-aligner": "^0.3.0",
+    "usfm-js": "^2.1.0"
   },
   "dependencies": {
     "@material-ui/core": "^3.9.4",
@@ -80,8 +81,7 @@
     "react-container-dimensions": "^1.3.3",
     "react-draggable": "^3.3.2",
     "react-remarkable": "^1.1.3",
-    "react-tooltip": "^3.11.6",
-    "usfm-js": "2.0.4-alpha"
+    "react-tooltip": "^3.11.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
@@ -123,6 +123,7 @@
     "style-loader": "1.1.3",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11",
-    "word-aligner": "0.3.0"
+    "word-aligner": "0.3.0",
+    "usfm-js": "2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "3.0.1",
+  "version": "3.0.1-alpha",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-draggable": "^3.3.2",
     "react-remarkable": "^1.1.3",
     "react-tooltip": "^3.11.6",
-    "usfm-js": "github:unfoldingWord/usfm-js#bugfix-mcleanb-6847"
+    "usfm-js": "2.0.4-alpha"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "2.1.0",
+  "version": "2.1.1-alpha",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "string-punctuation-tokenizer": "^2.0.0",
-    "word-aligner": "^0.3.0",
+    "word-aligner": "^0.4.0",
     "usfm-js": "^2.1.0"
   },
   "dependencies": {
@@ -123,7 +123,7 @@
     "style-loader": "1.1.3",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11",
-    "word-aligner": "0.3.0",
+    "word-aligner": "0.4.0",
     "usfm-js": "2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-draggable": "^3.3.2",
     "react-remarkable": "^1.1.3",
     "react-tooltip": "^3.11.6",
-    "usfm-js": "2.0.2"
+    "usfm-js": "github:unfoldingWord/usfm-js#bugfix-mcleanb-6847"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-draggable": "^3.3.2",
     "react-remarkable": "^1.1.3",
     "react-tooltip": "^3.11.6",
-    "usfm-js": "2.0.1"
+    "usfm-js": "2.0.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fixed removeMarker to work better with deeply nested spans and broken USFM. Will now show all target words in SP and word bank, and better invalidation checking in WA

#### Please include detailed Test instructions for your pull request:
- checkout tC branch `bugfix-mcleanb-6847`, run `npm run load-apps && npm ci && npm start`
- use github build attached to https://github.com/unfoldingWord/translationCore/pull/6966
- open project at https://drive.google.com/open?id=1nkSWNnvqHw_QVDaU5dIzNf9GZetrEB4Y
- when you open project, should see 38 new invalidations for WA
- open WA and navigate to luke 4:19
- the old builds would not show invalidations until project was exported, and would only show `4:19 और का प्रचार करूँ।”` in SP and only 4 words in the word bank
- but in this build 4:19 should show invalidated icon.  Also you should see many more words in word bank and SP as:  
![Screen Shot 2020-06-04 at 10 07 47 AM copy](https://user-images.githubusercontent.com/14238574/83773109-20709680-a652-11ea-83d6-12f64bdd2b36.png)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/269)
<!-- Reviewable:end -->
