### PR TITLE
Bugfix 6984/Fix for Hebrew fonts being clipped and too bold

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "3.0.5",
+  "version": "3.0.5-beta",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "3.0.5-beta",
+  "version": "3.0.6",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/src/ScripturePane/ScripturePane.js
+++ b/src/ScripturePane/ScripturePane.js
@@ -124,7 +124,7 @@ function ScripturePane({
         const isTargetBible = bibleId === 'targetBible';
 
         if (typeof verseData === 'string') { // if the verse content is string.
-          verseElements = verseString(verseData, selections, translate, setFontSize, isTargetBible, targetLanguageFont);
+          verseElements = verseString(verseData, selections, translate, fontStyle, isTargetBible, targetLanguageFont);
         } else if (verseData) { // else the verse content is an array of verse objects.
           verseElements = verseArray(verseData, bibleId, contextId, getLexiconData, showPopover, translate, fontStyle);
         }

--- a/src/ScripturePane/ScripturePane.js
+++ b/src/ScripturePane/ScripturePane.js
@@ -109,7 +109,7 @@ function ScripturePane({
         let verseElements = [];
 
         // TODO: this is temporary hack, there is a later issue to make font size user adjustable
-        const fontStyle = (manifest.language_id === 'hbo') ? { fontSize: '175%',  WebkitFontSmoothing: 'antialiased' } : null;
+        const fontStyle = (manifest.language_id === 'hbo') ? { fontSize: '175%', WebkitFontSmoothing: 'antialiased' } : null;
 
         if ((languageId === 'targetLanguage') && (bibleId === 'targetBible')) { // if target bible/language, pull up actual name
           language_name = getTitleWithId(manifest.language_name, manifest.language_id);

--- a/src/ScripturePane/ScripturePane.js
+++ b/src/ScripturePane/ScripturePane.js
@@ -109,7 +109,7 @@ function ScripturePane({
         let verseElements = [];
 
         // TODO: this is temporary hack, there is a later issue to make font size user adjustable
-        const setFontSize = (manifest.language_id === 'hbo') ? 175 : 0;
+        const fontStyle = (manifest.language_id === 'hbo') ? { fontSize: '175%',  WebkitFontSmoothing: 'antialiased' } : null;
 
         if ((languageId === 'targetLanguage') && (bibleId === 'targetBible')) { // if target bible/language, pull up actual name
           language_name = getTitleWithId(manifest.language_name, manifest.language_id);
@@ -126,7 +126,7 @@ function ScripturePane({
         if (typeof verseData === 'string') { // if the verse content is string.
           verseElements = verseString(verseData, selections, translate, setFontSize, isTargetBible, targetLanguageFont);
         } else if (verseData) { // else the verse content is an array of verse objects.
-          verseElements = verseArray(verseData, bibleId, contextId, getLexiconData, showPopover, translate, setFontSize);
+          verseElements = verseArray(verseData, bibleId, contextId, getLexiconData, showPopover, translate, fontStyle);
         }
 
         let fontClass = '';

--- a/src/ScripturePane/helpers/verseHelpers.js
+++ b/src/ScripturePane/helpers/verseHelpers.js
@@ -22,12 +22,12 @@ import {
  * @param {String} verseText
  * @param {Array} selections - text selections to highlight
  * @param {Function} translate
- * @param {Number} fontSize
+ * @param {Object} fontStyle - font specific styling
  * @param {String} isTargetBible
  * @param {String} targetLanguageFont
  * @return {*}
  */
-export const verseString = (verseText, selections, translate, fontSize = 0, isTargetBible, targetLanguageFont) => {
+export const verseString = (verseText, selections, translate, fontStyle = 0, isTargetBible, targetLanguageFont) => {
   let newVerseText = removeMarker(verseText);
   newVerseText = newVerseText.replace(/\s+/g, ' ');
   // if string only contains spaces then make it an empty string
@@ -54,10 +54,13 @@ export const verseString = (verseText, selections, translate, fontSize = 0, isTa
     for (let i = 0, len = _selectionArray.length; i < len; i++) {
       const selection = _selectionArray[i];
       const index = i;
-      const spanStyle = { backgroundColor: selection.selected ? 'var(--highlight-color)' : '' };
+      let spanStyle = { backgroundColor: selection.selected ? 'var(--highlight-color)' : '' };
 
-      if (fontSize) {
-        spanStyle.fontSize = Math.round(fontSize) + '%';
+      if (fontStyle) {
+        spanStyle = {
+          ...spanStyle,
+          ...fontStyle,
+        };
       }
       verseTextSpans.push(
         <span key={index} className={fontClass} style={spanStyle}>
@@ -78,10 +81,10 @@ export const verseString = (verseText, selections, translate, fontSize = 0, isTa
  * @param {Function} getLexiconData
  * @param {Boolean} showPopover
  * @param {Function} translate
- * @param {Number} fontSize - if zero, will default to 100%
+ * @param {Object} fontStyle - font specific styling
  * @return {Array} - verse elements to display
  */
-export function verseArray(verseText = [], bibleId, contextId, getLexiconData, showPopover, translate, fontSize = 0) {
+export function verseArray(verseText = [], bibleId, contextId, getLexiconData, showPopover, translate, fontStyle = 0) {
   let words = VerseObjectUtils.getWordListForVerse(verseText);
   let wordSpacing = '';
   let previousWord = null;
@@ -128,10 +131,13 @@ export function verseArray(verseText = [], bibleId, contextId, getLexiconData, s
         // TRICKY: for now we are disabling lexicon popups for any bible that is not ugnt or uhb.  The reason for
         //            this is than some bibles have different strongs format.  We are waiting on long term solution.
         if (word.strong && origLangBible) { // if clickable
-          const spanStyle = { backgroundColor: isHighlightedWord ? 'var(--highlight-color)' : '' };
+          let spanStyle = { backgroundColor: isHighlightedWord ? 'var(--highlight-color)' : '' };
 
-          if (fontSize) {
-            spanStyle.fontSize = Math.round(fontSize) + '%';
+          if (fontStyle) {
+            spanStyle = {
+              ...spanStyle,
+              ...fontStyle,
+            };
           }
           verseSpan.push(
             <span

--- a/src/ScripturePane/helpers/verseHelpers.js
+++ b/src/ScripturePane/helpers/verseHelpers.js
@@ -27,7 +27,7 @@ import {
  * @param {String} targetLanguageFont
  * @return {*}
  */
-export const verseString = (verseText, selections, translate, fontStyle = 0, isTargetBible, targetLanguageFont) => {
+export const verseString = (verseText, selections, translate, fontStyle = null, isTargetBible, targetLanguageFont) => {
   let newVerseText = removeMarker(verseText);
   newVerseText = newVerseText.replace(/\s+/g, ' ');
   // if string only contains spaces then make it an empty string
@@ -84,7 +84,7 @@ export const verseString = (verseText, selections, translate, fontStyle = 0, isT
  * @param {Object} fontStyle - font specific styling
  * @return {Array} - verse elements to display
  */
-export function verseArray(verseText = [], bibleId, contextId, getLexiconData, showPopover, translate, fontStyle = 0) {
+export function verseArray(verseText = [], bibleId, contextId, getLexiconData, showPopover, translate, fontStyle = null) {
   let words = VerseObjectUtils.getWordListForVerse(verseText);
   let wordSpacing = '';
   let previousWord = null;

--- a/src/WordLexiconDetails/WordLexiconDetails.js
+++ b/src/WordLexiconDetails/WordLexiconDetails.js
@@ -103,7 +103,7 @@ function generateWordPart(translate, lemma, morphStr, strongsNum, strongs, lexic
   morphStr = morphStr || translate('morph_missing');
   const multipart = count > 1;
   const key = 'lexicon_details_' + pos;
-  const origLangStyle = isHebrew ? { fontSize: '1.7em' } : { fontSize: '1.2em' };
+  const origLangStyle = isHebrew ? { fontSize: '1.7em', WebkitFontSmoothing: 'antialiased' } : { fontSize: '1.2em' };
 
   if (strongsNum) {
     return <div key={key} style={{ margin: '0px 10px 0px 10px', maxWidth: '400px' }}>

--- a/src/WordLexiconDetails/WordLexiconDetails.js
+++ b/src/WordLexiconDetails/WordLexiconDetails.js
@@ -46,11 +46,11 @@ function getFormatted(html) {
  * @param {string} fontSize - font size to use for text
  * @return {*}
  */
-function generateDataSegment(label, text, isFormatted = false, fontSize = '1.0em') {
+function generateDataSegment(label, text, isFormatted = false, style = { fontSize: '1.0em' }) {
   return (isFormatted ?
-    <span><strong>{label}</strong> <span style={{ fontSize }}>{(text && getFormatted(text)) || ''}</span></span>
+    <span><strong>{label}</strong> <span style={{ style }}>{(text && getFormatted(text)) || ''}</span></span>
     :
-    <span><strong>{label}</strong> <span style={{ fontSize }}>{text}</span></span>
+    <span><strong>{label}</strong> <span style={{ style }}>{text}</span></span>
   );
 }
 
@@ -74,10 +74,10 @@ function generateLine(pos) {
  * @param {string} fontSize - font size to use for word
  * @return {*}
  */
-function generateWordEntry(multipart, word, fontSize = '1.2em') {
+function generateWordEntry(multipart, word, style = { fontSize: '1.2em' }) {
   return multipart ?
     <div style={{ margin: '0', padding: '0' }}>
-      <strong style={{ fontSize }}>{word}</strong>
+      <strong style={style}>{word}</strong>
       <br/>
     </div>
     : '';
@@ -103,13 +103,13 @@ function generateWordPart(translate, lemma, morphStr, strongsNum, strongs, lexic
   morphStr = morphStr || translate('morph_missing');
   const multipart = count > 1;
   const key = 'lexicon_details_' + pos;
-  const origLangFontSize = isHebrew ? '1.7em' : '1.2em';
+  const origLangStyle = isHebrew ? { fontSize: '1.7em' } : { fontSize: '1.2em' };
 
   if (strongsNum) {
     return <div key={key} style={{ margin: '0px 10px 0px 10px', maxWidth: '400px' }}>
       {generateLine(pos)}
-      {generateWordEntry(multipart, word, origLangFontSize)}
-      {generateDataSegment(translate('lemma'), lemma, false, origLangFontSize)}<br/>
+      {generateWordEntry(multipart, word, origLangStyle)}
+      {generateDataSegment(translate('lemma'), lemma, false, origLangStyle)}<br/>
       {generateDataSegment(translate('morphology'), morphStr)}<br/>
       {generateDataSegment(translate('strongs'), strongs)}<br/>
       {generateDataSegment(translate('lexicon'), lexicon, true)}<br/>
@@ -117,7 +117,7 @@ function generateWordPart(translate, lemma, morphStr, strongsNum, strongs, lexic
   } else { // not main word
     return <div key={key} style={{ margin: '0px 0px 0px 10px', maxWidth: '400px' }}>
       {generateLine(pos)}
-      {generateWordEntry(multipart, word, origLangFontSize)}
+      {generateWordEntry(multipart, word, origLangStyle)}
       {generateDataSegment(translate('morphology'), morphStr)}<br/>
     </div>;
   }

--- a/src/WordLexiconDetails/WordLexiconDetails.js
+++ b/src/WordLexiconDetails/WordLexiconDetails.js
@@ -46,11 +46,11 @@ function getFormatted(html) {
  * @param {string} fontSize - font size to use for text
  * @return {*}
  */
-function generateDataSegment(label, text, isFormatted = false, style = { fontSize: '1.0em' }) {
+function generateDataSegment(label, text, isFormatted = false, fontSize = '1.0em') {
   return (isFormatted ?
-    <span><strong>{label}</strong> <span style={{ style }}>{(text && getFormatted(text)) || ''}</span></span>
+    <span><strong>{label}</strong> <span style={{ fontSize }}>{(text && getFormatted(text)) || ''}</span></span>
     :
-    <span><strong>{label}</strong> <span style={{ style }}>{text}</span></span>
+    <span><strong>{label}</strong> <span style={{ fontSize }}>{text}</span></span>
   );
 }
 
@@ -74,10 +74,10 @@ function generateLine(pos) {
  * @param {string} fontSize - font size to use for word
  * @return {*}
  */
-function generateWordEntry(multipart, word, style = { fontSize: '1.2em' }) {
+function generateWordEntry(multipart, word, fontSize = '1.2em') {
   return multipart ?
     <div style={{ margin: '0', padding: '0' }}>
-      <strong style={style}>{word}</strong>
+      <strong style={{ fontSize }}>{word}</strong>
       <br/>
     </div>
     : '';
@@ -103,13 +103,13 @@ function generateWordPart(translate, lemma, morphStr, strongsNum, strongs, lexic
   morphStr = morphStr || translate('morph_missing');
   const multipart = count > 1;
   const key = 'lexicon_details_' + pos;
-  const origLangStyle = isHebrew ? { fontSize: '1.7em', WebkitFontSmoothing: 'antialiased' } : { fontSize: '1.2em' };
+  const origLangFontSize = isHebrew ? '1.7em' : '1.2em';
 
   if (strongsNum) {
     return <div key={key} style={{ margin: '0px 10px 0px 10px', maxWidth: '400px' }}>
       {generateLine(pos)}
-      {generateWordEntry(multipart, word, origLangStyle)}
-      {generateDataSegment(translate('lemma'), lemma, false, origLangStyle)}<br/>
+      {generateWordEntry(multipart, word, origLangFontSize)}
+      {generateDataSegment(translate('lemma'), lemma, false, origLangFontSize)}<br/>
       {generateDataSegment(translate('morphology'), morphStr)}<br/>
       {generateDataSegment(translate('strongs'), strongs)}<br/>
       {generateDataSegment(translate('lexicon'), lexicon, true)}<br/>
@@ -117,7 +117,7 @@ function generateWordPart(translate, lemma, morphStr, strongsNum, strongs, lexic
   } else { // not main word
     return <div key={key} style={{ margin: '0px 0px 0px 10px', maxWidth: '400px' }}>
       {generateLine(pos)}
-      {generateWordEntry(multipart, word, origLangStyle)}
+      {generateWordEntry(multipart, word, origLangFontSize)}
       {generateDataSegment(translate('morphology'), morphStr)}<br/>
     </div>;
   }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix for Hebrew fonts being clipped and too bold

#### Please include detailed Test instructions for your pull request:
- test with tC build bugfix-mcleanb-6984
- in OT projects in wA  should not see the clipping of Hebrew in Alignment grid area and text should be less bold:

<img width="910" alt="Screen Shot 2020-06-22 at 12 45 24 PM" src="https://user-images.githubusercontent.com/14238574/85313695-64eb9700-b486-11ea-872f-f4c666a6944a.png">


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/275)
<!-- Reviewable:end -->
