### PR TITLE
Bugfix 6988/Fix group menu tooltips overflow calculations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "4.0.2",
+  "version": "4.0.3-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2370,7 +2370,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         }
@@ -5102,7 +5102,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -5164,7 +5164,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -6908,7 +6908,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -7064,7 +7064,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -8108,7 +8108,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -8459,7 +8459,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
@@ -8658,7 +8658,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -8688,7 +8688,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
@@ -8842,7 +8842,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "4.0.3-alpha",
+  "version": "4.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "4.0.3-alpha",
+  "version": "4.0.3",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "4.0.1",
+  "version": "4.0.2-alpha",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -181,11 +181,12 @@ class MenuItem extends React.Component {
    * Check for the tooltip text overflow
    */
   checkOverflow = () => {
+    const { key } = this.props;
     const padding = 10; // correct for padding width
     const overflow =
       this.listItemTextRef.current.offsetWidth <
       this.textRef.current.offsetWidth + padding;
-    console.log(`checkOverflow(${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
+    console.log(`checkOverflow(${key}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
 
     if (overflow !== this.state.overflow) {
       this.setState({ overflow });

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -333,10 +333,10 @@ class MenuItem extends React.Component {
           <Tooltip
             enterDelay={300}
             title={
-              <React.Fragment>
-                <span className={fontClass} style={toolTipStyle}>{tooltipText}</span>
+              <div style={toolTipStyle}>
+                <span className={fontClass}>{tooltipText}</span>
                 <span className={classes.arrow} ref={this.handleArrowRef}/>
-              </React.Fragment>
+              </div>
             }
             disableFocusListener={!overflow}
             disableHoverListener={!overflow}

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -182,16 +182,18 @@ class MenuItem extends React.Component {
    * Check for the tooltip text overflow
    */
   checkOverflow = () => {
-    const { title } = this.props;
-    const padding = 20; // correct for padding width
-    const overflow =
-      this.listItemTextRef.current.offsetWidth <=
-      this.textRef.current.offsetWidth + padding;
-    console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
+    delay(500).then(() => { // after screen renders check sizing
+      const { title } = this.props;
+      const padding = 20; // correct for padding width
+      const overflow =
+        this.listItemTextRef.current.offsetWidth <=
+        this.textRef.current.offsetWidth + padding;
+      console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
 
-    if (overflow !== this.state.overflow) {
-      this.setState({ overflow });
-    }
+      if (overflow !== this.state.overflow) {
+        this.setState({ overflow });
+      }
+    });
   };
 
   /**
@@ -286,9 +288,7 @@ class MenuItem extends React.Component {
   }
 
   componentDidMount() {
-    delay(500).then(() => { // after screen renders check sizing
-      this.checkOverflow();
-    });
+    this.checkOverflow();
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -182,11 +182,11 @@ class MenuItem extends React.Component {
    */
   checkOverflow = () => {
     const { title } = this.props;
-    const padding = 0; // correct for padding width
+    const padding = 20; // correct for padding width
     const overflow =
       this.listItemTextRef.current.offsetWidth <=
-      this.textRef.current.offsetWidth + this.textRef.current.offsetLeft + padding;
-    console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef W=${this.textRef.current.offsetWidth} L=${this.textRef.current.offsetLeft}, padding ${padding}`);
+      this.textRef.current.offsetWidth + padding;
+    console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
 
     if (overflow !== this.state.overflow) {
       this.setState({ overflow });

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -181,12 +181,12 @@ class MenuItem extends React.Component {
    * Check for the tooltip text overflow
    */
   checkOverflow = () => {
-    const { key } = this.props;
+    const { title } = this.props;
     const padding = 10; // correct for padding width
     const overflow =
       this.listItemTextRef.current.offsetWidth <
       this.textRef.current.offsetWidth + padding;
-    console.log(`checkOverflow(${key}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
+    console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
 
     if (overflow !== this.state.overflow) {
       this.setState({ overflow });

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -183,7 +183,7 @@ class MenuItem extends React.Component {
    */
   checkOverflow = () => {
     const { title } = this.props;
-    const padding = 16; // correct for padding width
+    const padding = 20; // correct for padding width
     const overflow =
       this.listItemTextRef.current.offsetWidth <=
       this.textRef.current.offsetWidth + padding;

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -181,12 +181,10 @@ class MenuItem extends React.Component {
    * Check for the tooltip text overflow
    */
   checkOverflow = () => {
-    const { title } = this.props;
     const padding = 20; // correct for padding width
     const overflow =
       this.listItemTextRef.current.offsetWidth <=
       this.textRef.current.offsetWidth + padding;
-    console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
 
     if (overflow !== this.state.overflow) {
       this.setState({ overflow });

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -336,11 +336,11 @@ class MenuItem extends React.Component {
         {icon}
         <RootRef rootRef={this.listItemTextRef}>
           <Tooltip
-            arrow={true}
             enterDelay={300}
             title={
               <React.Fragment>
-                <span className={fontClass} style={toolTipStyle}>{tooltipText}</span>
+                <div className={fontClass} style={toolTipStyle}>{tooltipText}</div>
+                <span className={classes.arrow} ref={this.handleArrowRef}/>
               </React.Fragment>
             }
             disableFocusListener={!overflow}
@@ -353,6 +353,16 @@ class MenuItem extends React.Component {
               tooltipPlacementRight: classes.bootstrapPlacementRight,
               tooltipPlacementTop: classes.bootstrapPlacementTop,
               tooltipPlacementBottom: classes.bootstrapPlacementBottom,
+            }}
+            PopperProps={{
+              popperOptions: {
+                modifiers: {
+                  arrow: {
+                    enabled: Boolean(this.state.arrowRef),
+                    element: this.state.arrowRef,
+                  },
+                },
+              },
             }}
           >
             <ListItemText

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -336,7 +336,7 @@ class MenuItem extends React.Component {
         {icon}
         <RootRef rootRef={this.listItemTextRef}>
           <Tooltip
-            arrow
+            arrow={true}
             enterDelay={300}
             title={
               <React.Fragment>

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -184,9 +184,9 @@ class MenuItem extends React.Component {
     const { title } = this.props;
     const padding = 0; // correct for padding width
     const overflow =
-      this.listItemTextRef.current.offsetWidth <
-      this.textRef.current.scrollWidth;
-    console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.scrollWidth}, padding ${padding}`);
+      this.listItemTextRef.current.offsetWidth <=
+      this.textRef.current.offsetWidth + this.textRef.current.offsetLeft + padding;
+    console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef W=${this.textRef.current.offsetWidth} L=${this.textRef.current.offsetLeft}, padding ${padding}`);
 
     if (overflow !== this.state.overflow) {
       this.setState({ overflow });

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -10,7 +10,6 @@ import Badge from '@material-ui/core/Badge';
 import memoize from 'memoize-one';
 import _ from 'lodash';
 import { getFontClassName } from '../../common/fontUtils';
-import { delay } from '../../ScripturePane/helpers/utils';
 import { isLTR } from '../..';
 
 /**
@@ -320,6 +319,7 @@ class MenuItem extends React.Component {
       style.paddingRight = '16px';
       style.direction = 'rtl';
       toolTipStyle.direction = 'rtl';
+      toolTipStyle.direction = 'rtl';
     }
 
     return (
@@ -336,12 +336,12 @@ class MenuItem extends React.Component {
         {icon}
         <RootRef rootRef={this.listItemTextRef}>
           <Tooltip
+            arrow
             enterDelay={300}
             title={
-              <div style={toolTipStyle}>
-                <span className={fontClass}>{tooltipText}</span>
-                <span className={classes.arrow} ref={this.handleArrowRef}/>
-              </div>
+              <React.Fragment>
+                <span className={fontClass} style={toolTipStyle}>{tooltipText}</span>
+              </React.Fragment>
             }
             disableFocusListener={!overflow}
             disableHoverListener={!overflow}
@@ -353,16 +353,6 @@ class MenuItem extends React.Component {
               tooltipPlacementRight: classes.bootstrapPlacementRight,
               tooltipPlacementTop: classes.bootstrapPlacementTop,
               tooltipPlacementBottom: classes.bootstrapPlacementBottom,
-            }}
-            PopperProps={{
-              popperOptions: {
-                modifiers: {
-                  arrow: {
-                    enabled: Boolean(this.state.arrowRef),
-                    element: this.state.arrowRef,
-                  },
-                },
-              },
             }}
           >
             <ListItemText

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -183,12 +183,11 @@ class MenuItem extends React.Component {
    */
   checkOverflow = () => {
     delay(500).then(() => { // after screen renders check sizing
-      const { direction, title } = this.props;
+      const { direction } = this.props;
       const padding = isLTR(direction) ? 8 : 20; // correct for padding width
       const overflow =
         this.listItemTextRef.current.offsetWidth <=
         this.textRef.current.offsetWidth + padding;
-      console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
 
       if (overflow !== this.state.overflow) {
         this.setState({ overflow });

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -182,17 +182,17 @@ class MenuItem extends React.Component {
    * Check for the tooltip text overflow
    */
   checkOverflow = () => {
-    delay(500).then(() => { // after screen renders check sizing
-      const { direction } = this.props;
-      const padding = isLTR(direction) ? 8 : 20; // correct for padding width
-      const overflow =
-        this.listItemTextRef.current.offsetWidth <=
-        this.textRef.current.offsetWidth + padding;
+    const { direction, title } = this.props;
+    const padding = isLTR(direction) ? 8 : 20; // correct for padding width
+    const overflow =
+      this.listItemTextRef.current.offsetWidth <=
+      this.textRef.current.offsetWidth + padding;
+    console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
 
-      if (overflow !== this.state.overflow) {
-        this.setState({ overflow });
-      }
-    });
+    if (overflow !== this.state.overflow) {
+      console.log(`checkOverflow(${title.substr(0,5)}) updating Overflow ${overflow})`);
+      this.setState({ overflow });
+    }
   };
 
   /**

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -10,6 +10,7 @@ import Badge from '@material-ui/core/Badge';
 import memoize from 'memoize-one';
 import _ from 'lodash';
 import { getFontClassName } from '../../common/fontUtils';
+import { delay } from '../../ScripturePane/helpers/utils';
 import { isLTR } from '../..';
 
 /**
@@ -181,10 +182,12 @@ class MenuItem extends React.Component {
    * Check for the tooltip text overflow
    */
   checkOverflow = () => {
+    const { title } = this.props;
     const padding = 20; // correct for padding width
     const overflow =
       this.listItemTextRef.current.offsetWidth <=
       this.textRef.current.offsetWidth + padding;
+    console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
 
     if (overflow !== this.state.overflow) {
       this.setState({ overflow });
@@ -283,7 +286,9 @@ class MenuItem extends React.Component {
   }
 
   componentDidMount() {
-    this.checkOverflow();
+    delay(500).then(() => { // after screen renders check sizing
+      this.checkOverflow();
+    });
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -181,9 +181,10 @@ class MenuItem extends React.Component {
    * Check for the tooltip text overflow
    */
   checkOverflow = () => {
+    const padding = 16; // correct for padding width
     const overflow =
       this.listItemTextRef.current.offsetWidth <
-      this.textRef.current.offsetWidth;
+      this.textRef.current.offsetWidth + padding;
 
     if (overflow !== this.state.overflow) {
       this.setState({ overflow });

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -182,11 +182,11 @@ class MenuItem extends React.Component {
    */
   checkOverflow = () => {
     const { title } = this.props;
-    const padding = 10; // correct for padding width
+    const padding = 0; // correct for padding width
     const overflow =
       this.listItemTextRef.current.offsetWidth <
-      this.textRef.current.offsetWidth + padding;
-    console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
+      this.textRef.current.scrollWidth;
+    console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.scrollWidth}, padding ${padding}`);
 
     if (overflow !== this.state.overflow) {
       this.setState({ overflow });

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -181,7 +181,7 @@ class MenuItem extends React.Component {
    * Check for the tooltip text overflow
    */
   checkOverflow = () => {
-    const padding = 16; // correct for padding width
+    const padding = 10; // correct for padding width
     const overflow =
       this.listItemTextRef.current.offsetWidth <
       this.textRef.current.offsetWidth + padding;

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -181,7 +181,7 @@ class MenuItem extends React.Component {
    * Check for the tooltip text overflow
    */
   checkOverflow = () => {
-    const padding = 10; // correct for padding width
+    const padding = 8; // correct for padding width
     const overflow =
       this.listItemTextRef.current.offsetWidth <
       this.textRef.current.offsetWidth + padding;

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -183,7 +183,7 @@ class MenuItem extends React.Component {
    */
   checkOverflow = () => {
     const { title } = this.props;
-    const padding = 20; // correct for padding width
+    const padding = 16; // correct for padding width
     const overflow =
       this.listItemTextRef.current.offsetWidth <=
       this.textRef.current.offsetWidth + padding;

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -181,10 +181,11 @@ class MenuItem extends React.Component {
    * Check for the tooltip text overflow
    */
   checkOverflow = () => {
-    const padding = 8; // correct for padding width
+    const padding = 10; // correct for padding width
     const overflow =
       this.listItemTextRef.current.offsetWidth <
       this.textRef.current.offsetWidth + padding;
+    console.log(`checkOverflow(${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
 
     if (overflow !== this.state.overflow) {
       this.setState({ overflow });

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -182,9 +182,12 @@ class MenuItem extends React.Component {
    * Check for the tooltip text overflow
    */
   checkOverflow = () => {
+    const { direction } = this.props;
+    const rtl = !isLTR(direction);
+    const padding = rtl ? 20 : 8; // correct for padding width
+
     delay(500).then(() => { // after screen renders check sizing
       const { title } = this.props;
-      const padding = 20; // correct for padding width
       const overflow =
         this.listItemTextRef.current.offsetWidth <=
         this.textRef.current.offsetWidth + padding;

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -189,7 +189,7 @@ class MenuItem extends React.Component {
     delay(500).then(() => { // after screen renders check sizing
       const { title } = this.props;
       const overflow =
-        this.listItemTextRef.current.offsetWidth <=
+        this.listItemTextRef.current.offsetWidth <
         this.textRef.current.offsetWidth + padding;
       console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
 

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -308,11 +308,13 @@ class MenuItem extends React.Component {
     const icon = this.generateStatusIcon(status, statusIcons, selected);
     const fontClass = getFontClassName(targetLanguageFont);
     const style = {};
+    const toolTipStyle = {};
 
     if (!isLTR(direction)) { // if RTL
       style.textAlign = 'right';
       style.paddingRight = '16px';
       style.direction = 'rtl';
+      toolTipStyle.direction = 'rtl';
     }
 
     return (
@@ -332,7 +334,7 @@ class MenuItem extends React.Component {
             enterDelay={300}
             title={
               <React.Fragment>
-                <span className={fontClass}>{tooltipText}</span>
+                <span className={fontClass} style={toolTipStyle}>{tooltipText}</span>
                 <span className={classes.arrow} ref={this.handleArrowRef}/>
               </React.Fragment>
             }

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -183,11 +183,12 @@ class MenuItem extends React.Component {
    */
   checkOverflow = () => {
     delay(500).then(() => { // after screen renders check sizing
-      const { direction } = this.props;
+      const { direction, title } = this.props;
       const padding = isLTR(direction) ? 8 : 20; // correct for padding width
       const overflow =
         this.listItemTextRef.current.offsetWidth <
         this.textRef.current.offsetWidth + padding;
+      console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
 
       if (overflow !== this.state.overflow) {
         this.setState({ overflow });

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -186,7 +186,7 @@ class MenuItem extends React.Component {
       const { direction, title } = this.props;
       const padding = isLTR(direction) ? 8 : 20; // correct for padding width
       const overflow =
-        this.listItemTextRef.current.offsetWidth <
+        this.listItemTextRef.current.offsetWidth <=
         this.textRef.current.offsetWidth + padding;
       console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
 

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -182,16 +182,12 @@ class MenuItem extends React.Component {
    * Check for the tooltip text overflow
    */
   checkOverflow = () => {
-    const { direction } = this.props;
-    const rtl = !isLTR(direction);
-    const padding = rtl ? 20 : 8; // correct for padding width
-
     delay(500).then(() => { // after screen renders check sizing
-      const { title } = this.props;
+      const { direction } = this.props;
+      const padding = isLTR(direction) ? 8 : 20; // correct for padding width
       const overflow =
         this.listItemTextRef.current.offsetWidth <
         this.textRef.current.offsetWidth + padding;
-      console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
 
       if (overflow !== this.state.overflow) {
         this.setState({ overflow });

--- a/src/GroupedMenu/Menu/MenuItem.js
+++ b/src/GroupedMenu/Menu/MenuItem.js
@@ -181,15 +181,13 @@ class MenuItem extends React.Component {
    * Check for the tooltip text overflow
    */
   checkOverflow = () => {
-    const { direction, title } = this.props;
+    const { direction } = this.props;
     const padding = isLTR(direction) ? 8 : 20; // correct for padding width
     const overflow =
       this.listItemTextRef.current.offsetWidth <=
       this.textRef.current.offsetWidth + padding;
-    console.log(`checkOverflow(${title.substr(0,5)}) Overflow ${overflow}), listItemTextRef ${this.listItemTextRef.current.offsetWidth}, textRef ${this.textRef.current.offsetWidth}, padding ${padding}`);
 
     if (overflow !== this.state.overflow) {
-      console.log(`checkOverflow(${title.substr(0,5)}) updating Overflow ${overflow})`);
       this.setState({ overflow });
     }
   };

--- a/src/VerseCheck/helpers/selectionHelpers.js
+++ b/src/VerseCheck/helpers/selectionHelpers.js
@@ -168,7 +168,7 @@ export const rangesToSelections = (string, ranges) => {
 function updateTrimmedTextOccurence(string, selection, trimmedText) {
   let originalRanges = selectionsToRanges(string, [selection]);
 
-  if (originalRanges) {
+  if (originalRanges && originalRanges.length) {
     const offset = selection.text.indexOf(trimmedText); // get offset of trimmed from non-trimmed
     const originalRange = originalRanges[0];
     const newStartPosition = originalRange[0] + offset;


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- added compensation for padding on tooltip calculations
- added separate padding amounts for ltr and rtl.
- added sanity check for selection to make sure array is not empty
- added delay before overflow calculations to so that rendering completes first

#### Please include detailed Test instructions for your pull request:
- in tn and tw group menu overflows should show like this in rtl languages.  And group menu entries should not have book name:

<img width="610" alt="Screen Shot 2020-07-05 at 3 30 10 PM" src="https://user-images.githubusercontent.com/14238574/86540588-9297fd80-bed4-11ea-8748-dadfa9bdf3be.png">

- and for ltr languages:

<img width="551" alt="Screen Shot 2020-07-05 at 3 36 50 PM" src="https://user-images.githubusercontent.com/14238574/86540720-70eb4600-bed5-11ea-9da9-940ee25d2cb9.png">


- in WA group menu should show like this without book name in rtl languages:

<img width="786" alt="Screen Shot 2020-07-05 at 3 33 40 PM" src="https://user-images.githubusercontent.com/14238574/86540662-f6222b00-bed4-11ea-98d6-0d448f0cf00e.png">

- and for ltr languages:

<img width="580" alt="Screen Shot 2020-07-05 at 3 38 39 PM" src="https://user-images.githubusercontent.com/14238574/86540841-aee86a00-bed5-11ea-9631-07957d10d2e3.png">


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/279)
<!-- Reviewable:end -->
