### PR TITLE
Bugfix 7024/Fix double click near end of word in checking tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "4.0.5",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "4.0.4-alpha.4",
+  "version": "4.0.4-alpha.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "4.0.3",
+  "version": "4.0.4-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "4.0.4-alpha.4",
+  "version": "4.0.4-alpha.5",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "4.0.4-alpha.7",
+  "version": "4.0.4",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "4.0.5",
+  "version": "5.0.0",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "4.0.3-alpha.3",
+  "version": "4.0.4-alpha.2",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "4.0.4-alpha.2",
+  "version": "4.0.4-alpha.4",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "4.0.4-alpha.5",
+  "version": "4.0.4-alpha.6",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@material-ui/core": "^4.10.2",
     "@material-ui/icons": "^3.0.2",
     "deep-equal": "^1.1.1",
+    "json-stringify-safe": "5.0.1",
     "jest-environment-jsdom": "^24.9.0",
     "lodash": "^4.17.15",
     "marked": "^0.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "@material-ui/core": "^4.10.2",
     "@material-ui/icons": "^3.0.2",
     "deep-equal": "^1.1.1",
-    "json-stringify-safe": "5.0.1",
     "jest-environment-jsdom": "^24.9.0",
     "lodash": "^4.17.15",
     "marked": "^0.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "4.0.3",
+  "version": "4.0.3-alpha.3",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/src/VerseCheck/RenderSelectionTextComponent/index.js
+++ b/src/VerseCheck/RenderSelectionTextComponent/index.js
@@ -25,62 +25,35 @@ class RenderSelectionTextComponent extends Component {
   /**
    * get new selected text and update selections
    * @param {String} verseText - current verse text
-   * @param {Object} event - mouse event from callback
    */
-  getSelectionText(verseText, event) {
+  getSelectionText(verseText) {
     const selection = windowSelectionHelpers.getSelectionFromCurrentWindowSelection(verseText, this.doubleClick);
-    console.log(`getSelectionText() - selection ${JSON.stringify(selection)}`);
-
-    if (event) {
-      console.log(`getSelectionText() - event ${event}`, event);
-    }
     this.addSelection(selection);
   }
 
   /**
-   * keep track of mouse down events for double click calculations
+   * keep track of mouse down events for double click calculation
    * @param {Object} event - mouse event from callback
    */
   recordMouseDown(event) {
     this.lastMouseDnEvent = this.mouseDnEvent; // need two mouse down events for double click calcs
     this.mouseDnEvent = { ...event }; // shallow copy
-    console.log(`recordMouseDown() - this.mouseDnEvent.time = ${this.mouseDnEvent.timeStamp}`);
 
-    if (this.lastMouseDnEvent) {
+    if (this.lastMouseDnEvent) { // if we had a previous mouse down, check if this is a double click
       const delta = this.mouseDnEvent.timeStamp - this.lastMouseDnEvent.timeStamp;
-      console.log(`recordMouseDown() - time between clicks = ${delta}`);
-      const isDblClkTime = delta < DBL_CLK_TIME;
-
-      if (isDblClkTime) {
-        console.log(`recordMouseDown() - Double click time`);
-      }
+      const isDblClkTime = delta < DBL_CLK_TIME; // both clicks must be within time limit
 
       const deltaX = this.mouseDnEvent.clientX - this.lastMouseDnEvent.clientX;
-      console.log(`recordMouseDown() - x distance between clicks = ${deltaX}`);
-      const isDblClkX = Math.abs(deltaX) < DBL_CLK_DISTANCE;
-
-      if (isDblClkX) {
-        console.log(`recordMouseDown() - Double Click X`);
-      }
+      const isDblClkX = Math.abs(deltaX) < DBL_CLK_DISTANCE; // both clicks X change must be within limit
 
       const deltaY = this.mouseDnEvent.clientY - this.lastMouseDnEvent.clientY;
-      console.log(`recordMouseDown() - y distance between clicks = ${deltaY}`);
-      const isDblClkY = Math.abs(deltaY) < DBL_CLK_DISTANCE;
-
-      if (isDblClkY) {
-        console.log(`recordMouseDown() - Double Click Y`);
-      }
+      const isDblClkY = Math.abs(deltaY) < DBL_CLK_DISTANCE; // both clicks Y change must be within limit
 
       this.doubleClick = isDblClkTime && isDblClkX && isDblClkY;
 
       if (this.doubleClick) {
-        console.log(`recordMouseDown() - is Double Click`);
+        console.log(`recordMouseDown() - Double Click detected`);
       }
-
-      const bounds = event.currentTarget.getBoundingClientRect();
-      const x = event.clientX - bounds.left;
-      const y = event.clientY - bounds.top;
-      console.log(`recordMouseDown() - mouse position at (${x},${y}) in ${event.currentTarget.innerText}`);
     }
   }
 
@@ -92,9 +65,7 @@ class RenderSelectionTextComponent extends Component {
       openAlertDialog,
       changeSelectionsInLocalState,
     } = this.props;
-    console.log(`addSelection() - initial selections ${JSON.stringify(selections)}`);
     selections = selectionHelpers.addSelectionToSelections(selection, selections, verseText);
-    console.log(`addSelection() - final selections ${JSON.stringify(selections)}`);
 
     // this is a good place to preview selections before saved in state
     if (selections.length <= this.props.maximumSelections) {
@@ -174,7 +145,7 @@ class RenderSelectionTextComponent extends Component {
     }
     return (
       <div
-        onMouseUp={(e) => this.getSelectionText(verseText, e)}
+        onMouseUp={() => this.getSelectionText(verseText)}
         onMouseDown={(e) => this.recordMouseDown(e)}
         onMouseLeave={() => this.inDisplayBox(false)}
         onMouseEnter={() => this.inDisplayBox(true)}>

--- a/src/VerseCheck/RenderSelectionTextComponent/index.js
+++ b/src/VerseCheck/RenderSelectionTextComponent/index.js
@@ -19,14 +19,14 @@ class RenderSelectionTextComponent extends Component {
     }
   }
 
-  getSelectionText(verseText) {
+  getSelectionText(verseText, e) {
     const selection = windowSelectionHelpers.getSelectionFromCurrentWindowSelection(verseText);
     console.log(`getSelectionText() - selection ${JSON.stringify(selection)}`);
-    this.addSelection(selection);
-  }
 
-  doubleClick(e) {
-    console.log(`doubleClick() - selection ${JSON.stringify(e)}`);
+    if (e) {
+      console.log(`getSelectionText() - e ${JSON.stringify(e)}`);
+    }
+    this.addSelection(selection);
   }
 
   addSelection(selection) {
@@ -118,8 +118,7 @@ class RenderSelectionTextComponent extends Component {
       verseTextSpans = this.verseTextSpans(selections, verseText);
     }
     return (
-      <div onMouseUp={() => this.getSelectionText(verseText)} onMouseLeave={() => this.inDisplayBox(false)} onMouseEnter={() => this.inDisplayBox(true)}
-        onDblClick={(e) => this.doubleClick(e)}>
+      <div onMouseUp={(e) => this.getSelectionText(verseText, e)} onMouseLeave={() => this.inDisplayBox(false)} onMouseEnter={() => this.inDisplayBox(true)}>
         {verseTextSpans}
       </div>
     );

--- a/src/VerseCheck/RenderSelectionTextComponent/index.js
+++ b/src/VerseCheck/RenderSelectionTextComponent/index.js
@@ -7,7 +7,7 @@ import * as selectionHelpers from '../helpers/selectionHelpers';
 import * as stringHelpers from '../helpers/stringHelpers';
 
 const DBL_CLK_TIME = 1500;
-const DBL_CLK_DISTANCE = 4;
+const DBL_CLK_DISTANCE = 10;
 
 class RenderSelectionTextComponent extends Component {
   componentWillMount() {
@@ -45,29 +45,39 @@ class RenderSelectionTextComponent extends Component {
   recordMouseDown(event) {
     this.lastMouseDnEvent = this.mouseDnEvent; // need two mouse down events for double click calcs
     this.mouseDnEvent = { ...event }; // shallow copy
-    console.log(`recordMouseDown() - this.mouseDnEvent.time = ${this.mouseDnEvent.time}`);
+    console.log(`recordMouseDown() - this.mouseDnEvent.time = ${this.mouseDnEvent.timeStamp}`);
 
     if (this.lastMouseDnEvent) {
       const delta = this.mouseDnEvent.timeStamp - this.lastMouseDnEvent.timeStamp;
       console.log(`recordMouseDown() - time between clicks = ${delta}`);
+      const isDblClkTime = delta < DBL_CLK_TIME;
 
-      if (delta < DBL_CLK_TIME) {
+      if (isDblClkTime) {
         console.log(`recordMouseDown() - Double click time`);
       }
 
       const deltaX = this.mouseDnEvent.clientX - this.lastMouseDnEvent.clientX;
       console.log(`recordMouseDown() - x distance between clicks = ${deltaX}`);
+      const isDblClkX = Math.abs(deltaX) < DBL_CLK_DISTANCE;
 
-      if (Math.abs(deltaX) < DBL_CLK_DISTANCE) {
-        console.log(`recordMouseDown() - Double X`);
+      if (isDblClkX) {
+        console.log(`recordMouseDown() - Double Click X`);
       }
 
       const deltaY = this.mouseDnEvent.clientY - this.lastMouseDnEvent.clientY;
-      console.log(`recordMouseDown() - x distance between clicks = ${deltaY}`);
+      console.log(`recordMouseDown() - y distance between clicks = ${deltaY}`);
+      const isDblClkY = Math.abs(deltaY) < DBL_CLK_DISTANCE;
 
-      if (Math.abs(deltaY) < DBL_CLK_DISTANCE) {
-        console.log(`recordMouseDown() - Double Y`);
+      if (isDblClkY) {
+        console.log(`recordMouseDown() - Double Click Y`);
       }
+
+      if (isDblClkTime && isDblClkX && isDblClkY) {
+        console.log(`recordMouseDown() - is Double Click`);
+      }
+
+      const selectionStart = event.currentTarget.selectionStart;
+      console.log(`recordMouseDown() - selectionStart ${selectionStart && JSON.stringify(selectionStart)}`);
     }
   }
 

--- a/src/VerseCheck/RenderSelectionTextComponent/index.js
+++ b/src/VerseCheck/RenderSelectionTextComponent/index.js
@@ -19,14 +19,35 @@ class RenderSelectionTextComponent extends Component {
     }
   }
 
-  getSelectionText(verseText, e) {
+  /**
+   * get new selected text and update selections
+   * @param {String} verseText
+   * @param {Object} event
+   */
+  getSelectionText(verseText, event) {
     const selection = windowSelectionHelpers.getSelectionFromCurrentWindowSelection(verseText);
     console.log(`getSelectionText() - selection ${JSON.stringify(selection)}`);
 
-    if (e) {
-      console.log(`getSelectionText() - event ${e}`, e);
+    if (event) {
+      console.log(`getSelectionText() - event ${event}`, event);
     }
     this.addSelection(selection);
+  }
+
+  /**
+   * keep track of mouse down event for double click calculations
+   * @param {String} verseText
+   * @param {Object} event
+   */
+  recordMouseDown(event) {
+    this.lastMouseDnEvent = this.mouseDnEvent; // need two mouse down events for double click calcs
+    this.mouseDnEvent = event;
+    this.mouseDnEvent.time = Date.now(); // add time stamp
+
+    if (this.lastMouseDnEvent) {
+      const delta = this.mouseDnEvent.time - this.lastMouseDnEvent.time;
+      console.log(`recordMouseDown() - time between clicks = ${delta}`);
+    }
   }
 
   addSelection(selection) {
@@ -118,7 +139,11 @@ class RenderSelectionTextComponent extends Component {
       verseTextSpans = this.verseTextSpans(selections, verseText);
     }
     return (
-      <div onMouseUp={(e) => this.getSelectionText(verseText, e)} onMouseLeave={() => this.inDisplayBox(false)} onMouseEnter={() => this.inDisplayBox(true)}>
+      <div
+        onMouseUp={(e) => this.getSelectionText(verseText, e)}
+        onMouseDown={(e) => this.recordMouseDown(e)}
+        onMouseLeave={() => this.inDisplayBox(false)}
+        onMouseEnter={() => this.inDisplayBox(true)}>
         {verseTextSpans}
       </div>
     );

--- a/src/VerseCheck/RenderSelectionTextComponent/index.js
+++ b/src/VerseCheck/RenderSelectionTextComponent/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'deep-equal';
+import stringify from 'json-stringify-safe';
 // helpers
 import * as windowSelectionHelpers from '../helpers/windowSelectionHelpers';
 import * as selectionHelpers from '../helpers/selectionHelpers';
@@ -21,10 +22,10 @@ class RenderSelectionTextComponent extends Component {
 
   getSelectionText(verseText, e) {
     const selection = windowSelectionHelpers.getSelectionFromCurrentWindowSelection(verseText);
-    console.log(`getSelectionText() - selection ${JSON.stringify(selection)}`);
+    console.log(`getSelectionText() - selection ${stringify(selection)}`);
 
     if (e) {
-      console.log(`getSelectionText() - event ${JSON.stringify(e)}`);
+      console.log(`getSelectionText() - event ${stringify(e)}`);
     }
     this.addSelection(selection);
   }
@@ -37,9 +38,9 @@ class RenderSelectionTextComponent extends Component {
       openAlertDialog,
       changeSelectionsInLocalState,
     } = this.props;
-    console.log(`addSelection() - initial selections ${JSON.stringify(selections)}`);
+    console.log(`addSelection() - initial selections ${stringify(selections)}`);
     selections = selectionHelpers.addSelectionToSelections(selection, selections, verseText);
-    console.log(`addSelection() - final selections ${JSON.stringify(selections)}`);
+    console.log(`addSelection() - final selections ${stringify(selections)}`);
 
     // this is a good place to preview selections before saved in state
     if (selections.length <= this.props.maximumSelections) {

--- a/src/VerseCheck/RenderSelectionTextComponent/index.js
+++ b/src/VerseCheck/RenderSelectionTextComponent/index.js
@@ -21,7 +21,12 @@ class RenderSelectionTextComponent extends Component {
 
   getSelectionText(verseText) {
     const selection = windowSelectionHelpers.getSelectionFromCurrentWindowSelection(verseText);
+    console.log(`getSelectionText() - selection ${JSON.stringify(selection)}`);
     this.addSelection(selection);
+  }
+
+  doubleClick(e) {
+    console.log(`doubleClick() - selection ${JSON.stringify(e)}`);
   }
 
   addSelection(selection) {
@@ -32,7 +37,9 @@ class RenderSelectionTextComponent extends Component {
       openAlertDialog,
       changeSelectionsInLocalState,
     } = this.props;
+    console.log(`addSelection() - initial selections ${JSON.stringify(selections)}`);
     selections = selectionHelpers.addSelectionToSelections(selection, selections, verseText);
+    console.log(`addSelection() - final selections ${JSON.stringify(selections)}`);
 
     // this is a good place to preview selections before saved in state
     if (selections.length <= this.props.maximumSelections) {
@@ -111,7 +118,8 @@ class RenderSelectionTextComponent extends Component {
       verseTextSpans = this.verseTextSpans(selections, verseText);
     }
     return (
-      <div onMouseUp={() => this.getSelectionText(verseText)} onMouseLeave={() => this.inDisplayBox(false)} onMouseEnter={() => this.inDisplayBox(true)}>
+      <div onMouseUp={() => this.getSelectionText(verseText)} onMouseLeave={() => this.inDisplayBox(false)} onMouseEnter={() => this.inDisplayBox(true)}
+        onDblClick={(e) => this.doubleClick(e)}>
         {verseTextSpans}
       </div>
     );

--- a/src/VerseCheck/RenderSelectionTextComponent/index.js
+++ b/src/VerseCheck/RenderSelectionTextComponent/index.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'deep-equal';
-import stringify from 'json-stringify-safe';
 // helpers
 import * as windowSelectionHelpers from '../helpers/windowSelectionHelpers';
 import * as selectionHelpers from '../helpers/selectionHelpers';
@@ -22,10 +21,10 @@ class RenderSelectionTextComponent extends Component {
 
   getSelectionText(verseText, e) {
     const selection = windowSelectionHelpers.getSelectionFromCurrentWindowSelection(verseText);
-    console.log(`getSelectionText() - selection ${stringify(selection)}`);
+    console.log(`getSelectionText() - selection ${JSON.stringify(selection)}`);
 
     if (e) {
-      console.log(`getSelectionText() - event ${stringify(e)}`);
+      console.log(`getSelectionText() - event ${e}`, e);
     }
     this.addSelection(selection);
   }
@@ -38,9 +37,9 @@ class RenderSelectionTextComponent extends Component {
       openAlertDialog,
       changeSelectionsInLocalState,
     } = this.props;
-    console.log(`addSelection() - initial selections ${stringify(selections)}`);
+    console.log(`addSelection() - initial selections ${JSON.stringify(selections)}`);
     selections = selectionHelpers.addSelectionToSelections(selection, selections, verseText);
-    console.log(`addSelection() - final selections ${stringify(selections)}`);
+    console.log(`addSelection() - final selections ${JSON.stringify(selections)}`);
 
     // this is a good place to preview selections before saved in state
     if (selections.length <= this.props.maximumSelections) {

--- a/src/VerseCheck/RenderSelectionTextComponent/index.js
+++ b/src/VerseCheck/RenderSelectionTextComponent/index.js
@@ -6,6 +6,9 @@ import * as windowSelectionHelpers from '../helpers/windowSelectionHelpers';
 import * as selectionHelpers from '../helpers/selectionHelpers';
 import * as stringHelpers from '../helpers/stringHelpers';
 
+const DBL_CLK_TIME = 1500;
+const DBL_CLK_DISTANCE = 10;
+
 class RenderSelectionTextComponent extends Component {
   componentWillMount() {
     // track when the selections change to prevent false clicks of removals
@@ -25,13 +28,61 @@ class RenderSelectionTextComponent extends Component {
    * @param {Object} event
    */
   getSelectionText(verseText, event) {
-    const selection = windowSelectionHelpers.getSelectionFromCurrentWindowSelection(verseText);
+    const selection = windowSelectionHelpers.getSelectionFromCurrentWindowSelection(verseText, this.doubleClick);
     console.log(`getSelectionText() - selection ${JSON.stringify(selection)}`);
 
     if (event) {
       console.log(`getSelectionText() - event ${event}`, event);
     }
     this.addSelection(selection);
+  }
+
+  /**
+   * keep track of mouse down event for double click calculations
+   * @param {String} verseText
+   * @param {Object} event
+   */
+  recordMouseDown(event) {
+    this.lastMouseDnEvent = this.mouseDnEvent; // need two mouse down events for double click calcs
+    this.mouseDnEvent = { ...event }; // shallow copy
+    console.log(`recordMouseDown() - this.mouseDnEvent.time = ${this.mouseDnEvent.timeStamp}`);
+
+    if (this.lastMouseDnEvent) {
+      const delta = this.mouseDnEvent.timeStamp - this.lastMouseDnEvent.timeStamp;
+      console.log(`recordMouseDown() - time between clicks = ${delta}`);
+      const isDblClkTime = delta < DBL_CLK_TIME;
+
+      if (isDblClkTime) {
+        console.log(`recordMouseDown() - Double click time`);
+      }
+
+      const deltaX = this.mouseDnEvent.clientX - this.lastMouseDnEvent.clientX;
+      console.log(`recordMouseDown() - x distance between clicks = ${deltaX}`);
+      const isDblClkX = Math.abs(deltaX) < DBL_CLK_DISTANCE;
+
+      if (isDblClkX) {
+        console.log(`recordMouseDown() - Double Click X`);
+      }
+
+      const deltaY = this.mouseDnEvent.clientY - this.lastMouseDnEvent.clientY;
+      console.log(`recordMouseDown() - y distance between clicks = ${deltaY}`);
+      const isDblClkY = Math.abs(deltaY) < DBL_CLK_DISTANCE;
+
+      if (isDblClkY) {
+        console.log(`recordMouseDown() - Double Click Y`);
+      }
+
+      this.doubleClick = isDblClkTime && isDblClkX && isDblClkY;
+
+      if (this.doubleClick) {
+        console.log(`recordMouseDown() - is Double Click`);
+      }
+
+      const bounds = event.currentTarget.getBoundingClientRect();
+      const x = event.clientX - bounds.left;
+      const y = event.clientY - bounds.top;
+      console.log(`recordMouseDown() - mouse position at (${x},${y}) in ${event.currentTarget.innerText}`);
+    }
   }
 
   addSelection(selection) {

--- a/src/VerseCheck/RenderSelectionTextComponent/index.js
+++ b/src/VerseCheck/RenderSelectionTextComponent/index.js
@@ -176,6 +176,7 @@ class RenderSelectionTextComponent extends Component {
     return (
       <div
         onMouseUp={(e) => this.getSelectionText(verseText, e)}
+        onMouseDown={(e) => this.recordMouseDown(e)}
         onMouseLeave={() => this.inDisplayBox(false)}
         onMouseEnter={() => this.inDisplayBox(true)}>
         {verseTextSpans}

--- a/src/VerseCheck/RenderSelectionTextComponent/index.js
+++ b/src/VerseCheck/RenderSelectionTextComponent/index.js
@@ -6,9 +6,6 @@ import * as windowSelectionHelpers from '../helpers/windowSelectionHelpers';
 import * as selectionHelpers from '../helpers/selectionHelpers';
 import * as stringHelpers from '../helpers/stringHelpers';
 
-const DBL_CLK_TIME = 1500;
-const DBL_CLK_DISTANCE = 10;
-
 class RenderSelectionTextComponent extends Component {
   componentWillMount() {
     // track when the selections change to prevent false clicks of removals
@@ -35,52 +32,6 @@ class RenderSelectionTextComponent extends Component {
       console.log(`getSelectionText() - event ${event}`, event);
     }
     this.addSelection(selection);
-  }
-
-  /**
-   * keep track of mouse down event for double click calculations
-   * @param {String} verseText
-   * @param {Object} event
-   */
-  recordMouseDown(event) {
-    this.lastMouseDnEvent = this.mouseDnEvent; // need two mouse down events for double click calcs
-    this.mouseDnEvent = { ...event }; // shallow copy
-    console.log(`recordMouseDown() - this.mouseDnEvent.time = ${this.mouseDnEvent.timeStamp}`);
-
-    if (this.lastMouseDnEvent) {
-      const delta = this.mouseDnEvent.timeStamp - this.lastMouseDnEvent.timeStamp;
-      console.log(`recordMouseDown() - time between clicks = ${delta}`);
-      const isDblClkTime = delta < DBL_CLK_TIME;
-
-      if (isDblClkTime) {
-        console.log(`recordMouseDown() - Double click time`);
-      }
-
-      const deltaX = this.mouseDnEvent.clientX - this.lastMouseDnEvent.clientX;
-      console.log(`recordMouseDown() - x distance between clicks = ${deltaX}`);
-      const isDblClkX = Math.abs(deltaX) < DBL_CLK_DISTANCE;
-
-      if (isDblClkX) {
-        console.log(`recordMouseDown() - Double Click X`);
-      }
-
-      const deltaY = this.mouseDnEvent.clientY - this.lastMouseDnEvent.clientY;
-      console.log(`recordMouseDown() - y distance between clicks = ${deltaY}`);
-      const isDblClkY = Math.abs(deltaY) < DBL_CLK_DISTANCE;
-
-      if (isDblClkY) {
-        console.log(`recordMouseDown() - Double Click Y`);
-      }
-
-      if (isDblClkTime && isDblClkX && isDblClkY) {
-        console.log(`recordMouseDown() - is Double Click`);
-      }
-
-      const bounds = event.currentTarget.getBoundingClientRect();
-      const x = event.clientX - bounds.left;
-      const y = event.clientY - bounds.top;
-      console.log(`recordMouseDown() - mouse position at (${x},${y}) in ${event.currentTarget.innerText}`);
-    }
   }
 
   addSelection(selection) {
@@ -174,7 +125,6 @@ class RenderSelectionTextComponent extends Component {
     return (
       <div
         onMouseUp={(e) => this.getSelectionText(verseText, e)}
-        onMouseDown={(e) => this.recordMouseDown(e)}
         onMouseLeave={() => this.inDisplayBox(false)}
         onMouseEnter={() => this.inDisplayBox(true)}>
         {verseTextSpans}

--- a/src/VerseCheck/RenderSelectionTextComponent/index.js
+++ b/src/VerseCheck/RenderSelectionTextComponent/index.js
@@ -6,6 +6,9 @@ import * as windowSelectionHelpers from '../helpers/windowSelectionHelpers';
 import * as selectionHelpers from '../helpers/selectionHelpers';
 import * as stringHelpers from '../helpers/stringHelpers';
 
+const DBL_CLK_TIME = 1500;
+const DBL_CLK_DISTANCE = 4;
+
 class RenderSelectionTextComponent extends Component {
   componentWillMount() {
     // track when the selections change to prevent false clicks of removals
@@ -41,14 +44,30 @@ class RenderSelectionTextComponent extends Component {
    */
   recordMouseDown(event) {
     this.lastMouseDnEvent = this.mouseDnEvent; // need two mouse down events for double click calcs
-    this.mouseDnEvent = { ...event };
-    this.mouseDnEvent.time = Date.now(); // add time stamp
+    this.mouseDnEvent = { ...event }; // shallow copy
     console.log(`recordMouseDown() - this.mouseDnEvent.time = ${this.mouseDnEvent.time}`);
-    console.log(`recordMouseDown() - this.mouseDnEvent.timeStamp = ${this.mouseDnEvent.timeStamp}`);
 
     if (this.lastMouseDnEvent) {
-      const delta = this.mouseDnEvent.time - this.lastMouseDnEvent.time;
+      const delta = this.mouseDnEvent.timeStamp - this.lastMouseDnEvent.timeStamp;
       console.log(`recordMouseDown() - time between clicks = ${delta}`);
+
+      if (delta < DBL_CLK_TIME) {
+        console.log(`recordMouseDown() - Double click time`);
+      }
+
+      const deltaX = this.mouseDnEvent.clientX - this.lastMouseDnEvent.clientX;
+      console.log(`recordMouseDown() - x distance between clicks = ${deltaX}`);
+
+      if (Math.abs(deltaX) < DBL_CLK_DISTANCE) {
+        console.log(`recordMouseDown() - Double X`);
+      }
+
+      const deltaY = this.mouseDnEvent.clientY - this.lastMouseDnEvent.clientY;
+      console.log(`recordMouseDown() - x distance between clicks = ${deltaY}`);
+
+      if (Math.abs(deltaY) < DBL_CLK_DISTANCE) {
+        console.log(`recordMouseDown() - Double Y`);
+      }
     }
   }
 

--- a/src/VerseCheck/RenderSelectionTextComponent/index.js
+++ b/src/VerseCheck/RenderSelectionTextComponent/index.js
@@ -76,8 +76,10 @@ class RenderSelectionTextComponent extends Component {
         console.log(`recordMouseDown() - is Double Click`);
       }
 
-      const selectionStart = event.currentTarget.selectionStart;
-      console.log(`recordMouseDown() - selectionStart ${selectionStart && JSON.stringify(selectionStart)}`);
+      const bounds = event.currentTarget.getBoundingClientRect();
+      const x = event.clientX - bounds.left;
+      const y = event.clientY - bounds.top;
+      console.log(`recordMouseDown() - mouse position at (${x},${y}) in ${event.currentTarget.innerText}`);
     }
   }
 

--- a/src/VerseCheck/RenderSelectionTextComponent/index.js
+++ b/src/VerseCheck/RenderSelectionTextComponent/index.js
@@ -6,8 +6,8 @@ import * as windowSelectionHelpers from '../helpers/windowSelectionHelpers';
 import * as selectionHelpers from '../helpers/selectionHelpers';
 import * as stringHelpers from '../helpers/stringHelpers';
 
-const DBL_CLK_TIME = 1500;
-const DBL_CLK_DISTANCE = 10;
+const DBL_CLK_TIME = 1500; // time in ms
+const DBL_CLK_DISTANCE = 10; // in pixels
 
 class RenderSelectionTextComponent extends Component {
   componentWillMount() {
@@ -24,8 +24,8 @@ class RenderSelectionTextComponent extends Component {
 
   /**
    * get new selected text and update selections
-   * @param {String} verseText
-   * @param {Object} event
+   * @param {String} verseText - current verse text
+   * @param {Object} event - mouse event from callback
    */
   getSelectionText(verseText, event) {
     const selection = windowSelectionHelpers.getSelectionFromCurrentWindowSelection(verseText, this.doubleClick);
@@ -38,9 +38,8 @@ class RenderSelectionTextComponent extends Component {
   }
 
   /**
-   * keep track of mouse down event for double click calculations
-   * @param {String} verseText
-   * @param {Object} event
+   * keep track of mouse down events for double click calculations
+   * @param {Object} event - mouse event from callback
    */
   recordMouseDown(event) {
     this.lastMouseDnEvent = this.mouseDnEvent; // need two mouse down events for double click calcs

--- a/src/VerseCheck/RenderSelectionTextComponent/index.js
+++ b/src/VerseCheck/RenderSelectionTextComponent/index.js
@@ -24,7 +24,7 @@ class RenderSelectionTextComponent extends Component {
     console.log(`getSelectionText() - selection ${JSON.stringify(selection)}`);
 
     if (e) {
-      console.log(`getSelectionText() - e ${JSON.stringify(e)}`);
+      console.log(`getSelectionText() - event ${JSON.stringify(e)}`);
     }
     this.addSelection(selection);
   }

--- a/src/VerseCheck/RenderSelectionTextComponent/index.js
+++ b/src/VerseCheck/RenderSelectionTextComponent/index.js
@@ -41,8 +41,10 @@ class RenderSelectionTextComponent extends Component {
    */
   recordMouseDown(event) {
     this.lastMouseDnEvent = this.mouseDnEvent; // need two mouse down events for double click calcs
-    this.mouseDnEvent = event;
+    this.mouseDnEvent = { ...event };
     this.mouseDnEvent.time = Date.now(); // add time stamp
+    console.log(`recordMouseDown() - this.mouseDnEvent.time = ${this.mouseDnEvent.time}`);
+    console.log(`recordMouseDown() - this.mouseDnEvent.timeStamp = ${this.mouseDnEvent.timeStamp}`);
 
     if (this.lastMouseDnEvent) {
       const delta = this.mouseDnEvent.time - this.lastMouseDnEvent.time;

--- a/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
+++ b/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
@@ -742,6 +742,7 @@ exports[`VerseCheck component: Integrated View test 1`] = `
               style={Object {}}
             >
               <div
+                onMouseDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 onMouseUp={[Function]}
@@ -1434,6 +1435,7 @@ exports[`VerseCheck component: Integrated View test with invalidated 1`] = `
               style={Object {}}
             >
               <div
+                onMouseDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 onMouseUp={[Function]}
@@ -1788,6 +1790,7 @@ exports[`VerseCheck component: Integrated View test with verseEdit 1`] = `
               style={Object {}}
             >
               <div
+                onMouseDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 onMouseUp={[Function]}

--- a/src/VerseCheck/helpers/selectionHelpers.js
+++ b/src/VerseCheck/helpers/selectionHelpers.js
@@ -167,6 +167,7 @@ export const rangesToSelections = (string, ranges) => {
  */
 function updateTrimmedTextOccurence(string, selection, trimmedText) {
   let originalRanges = selectionsToRanges(string, [selection]);
+  console.log(`updateTrimmedTextOccurence() string: ${string}, selection: ${JSON.stringify(selection)}, trimmedText: ${trimmedText}, originalRanges: ${JSON.stringify(originalRanges)}`);
 
   if (originalRanges && originalRanges.length) {
     const offset = selection.text.indexOf(trimmedText); // get offset of trimmed from non-trimmed

--- a/src/VerseCheck/helpers/selectionHelpers.js
+++ b/src/VerseCheck/helpers/selectionHelpers.js
@@ -167,7 +167,6 @@ export const rangesToSelections = (string, ranges) => {
  */
 function updateTrimmedTextOccurence(string, selection, trimmedText) {
   let originalRanges = selectionsToRanges(string, [selection]);
-  console.log(`updateTrimmedTextOccurence() string: ${string}, selection: ${JSON.stringify(selection)}, trimmedText: ${trimmedText}, originalRanges: ${JSON.stringify(originalRanges)}`);
 
   if (originalRanges && originalRanges.length) {
     const offset = selection.text.indexOf(trimmedText); // get offset of trimmed from non-trimmed

--- a/src/VerseCheck/helpers/stringHelpers.js
+++ b/src/VerseCheck/helpers/stringHelpers.js
@@ -35,20 +35,20 @@ export const normalizeString = (string) => {
   return string;
 };
 /**
- * @description - generates a selection object from the selected text, prescedingText and whole text
+ * @description - generates a selection object from the selected text, precedingText and whole text
  * @param {String} selectedText - the text that is selected
- * @param {String} prescedingText - the text that prescedes the selection
+ * @param {String} precedingText - the text that precedes the selection
  * @param {String} entireText - the text that the selection should be in
  * @return {Object} - the selection object to be used
  */
-export const generateSelection = (selectedText, prescedingText, entireText) => {
+export const generateSelection = (selectedText, precedingText, entireText) => {
   let selection = {}; // response
   // replace more than one contiguous space with a single one since HTML/selection only renders 1
   entireText = normalizeString(entireText);
   // get the occurrences before this one
-  let prescedingOccurrences = occurrencesInString(prescedingText, selectedText);
-  // calculate this occurrence number by adding it to the presceding ones
-  let occurrence = prescedingOccurrences + 1;
+  let precedingOccurrences = occurrencesInString(precedingText, selectedText);
+  // calculate this occurrence number by adding it to the preceding ones
+  let occurrence = precedingOccurrences + 1;
   // get the total occurrences from the verse
   let occurrences = occurrencesInString(entireText, selectedText);
 

--- a/src/VerseCheck/helpers/windowSelectionHelpers.js
+++ b/src/VerseCheck/helpers/windowSelectionHelpers.js
@@ -4,10 +4,11 @@ import * as stringHelpers from './stringHelpers';
 /**
  * @description - Gets the selection object from the currently selected text from the Web UI
  * @param {String} entireText - the text that the selection should be in, ie verseText
+ * @param {Boolean} fallbackToPreviousWord - if true then we select previous word if selection is at end
  * @return {Object} - the selection object to be used
  * TODO: Find a way to test
  */
-export const getSelectionFromCurrentWindowSelection = (entireText) => {
+export const getSelectionFromCurrentWindowSelection = (entireText, fallbackToPreviousWord = false) => {
   let selection; // response
   const windowSelection = getCurrentWindowSelection();
   console.log(`getSelectionFromCurrentWindowSelection() - windowSelection ${JSON.stringify(windowSelection)}`);
@@ -17,7 +18,9 @@ export const getSelectionFromCurrentWindowSelection = (entireText) => {
   let precedingText = getPrecedingTextFromWindowSelection(windowSelection);
   console.log(`getSelectionFromCurrentWindowSelection() - precedingText ${JSON.stringify(precedingText)}`);
 
-  if (selectedText === '') { // handle edge case of clicking near end of word
+  console.log(`getSelectionFromCurrentWindowSelection() - fallbackToPreviousWord ${fallbackToPreviousWord}`);
+
+  if (fallbackToPreviousWord && (selectedText === '')) { // handle edge case of clicking near end of word
     const words = tokenize({ text: precedingText });
 
     if (words && words.length) {

--- a/src/VerseCheck/helpers/windowSelectionHelpers.js
+++ b/src/VerseCheck/helpers/windowSelectionHelpers.js
@@ -12,9 +12,9 @@ export const getSelectionFromCurrentWindowSelection = (entireText) => {
   console.log(`getSelectionFromCurrentWindowSelection() - windowSelection ${JSON.stringify(windowSelection)}`);
   const selectedText = getSelectedTextFromWindowSelection(windowSelection);
   console.log(`getSelectionFromCurrentWindowSelection() - selectedText ${JSON.stringify(selectedText)}`);
-  console.log(`getSelectionFromCurrentWindowSelection() - selectedText ${JSON.stringify(selectedText)}`);
-  const prescedingText = getPrescedingTextFromWindowSelection(windowSelection);
   console.log(`getSelectionFromCurrentWindowSelection() - windowSelection.rangeCount ${windowSelection.rangeCount}`);
+  const prescedingText = getPrescedingTextFromWindowSelection(windowSelection);
+  console.log(`getSelectionFromCurrentWindowSelection() - prescedingText ${JSON.stringify(prescedingText)}`);
   // Some edge cases leave a weird selection remaining, let's clean up.
   selection = stringHelpers.generateSelection(selectedText, prescedingText, entireText);
   window.getSelection().empty();

--- a/src/VerseCheck/helpers/windowSelectionHelpers.js
+++ b/src/VerseCheck/helpers/windowSelectionHelpers.js
@@ -30,6 +30,8 @@ export const getSelectionFromCurrentWindowSelection = (entireText) => {
           // use last word for selection
           selectedText = lastWord;
           precedingText = precedingText.substr(0, pos);
+          console.log(`getSelectionFromCurrentWindowSelection() - switching to last word, selectedText ${JSON.stringify(selectedText)}`);
+          console.log(`getSelectionFromCurrentWindowSelection() - precedingText ${JSON.stringify(precedingText)}`);
         }
       }
     }

--- a/src/VerseCheck/helpers/windowSelectionHelpers.js
+++ b/src/VerseCheck/helpers/windowSelectionHelpers.js
@@ -20,7 +20,7 @@ export const getSelectionFromCurrentWindowSelection = (entireText, fallbackToPre
 
   console.log(`getSelectionFromCurrentWindowSelection() - fallbackToPreviousWord ${fallbackToPreviousWord}`);
 
-  if (fallbackToPreviousWord && (selectedText === '')) { // handle edge case of clicking near end of word
+  if (fallbackToPreviousWord && (selectedText === ' ')) { // handle edge case of clicking near end of word
     const words = tokenize({ text: precedingText });
 
     if (words && words.length) {

--- a/src/VerseCheck/helpers/windowSelectionHelpers.js
+++ b/src/VerseCheck/helpers/windowSelectionHelpers.js
@@ -11,14 +11,8 @@ import * as stringHelpers from './stringHelpers';
 export const getSelectionFromCurrentWindowSelection = (entireText, fallbackToPreviousWord = false) => {
   let selection; // response
   const windowSelection = getCurrentWindowSelection();
-  console.log(`getSelectionFromCurrentWindowSelection() - windowSelection ${JSON.stringify(windowSelection)}`);
   let selectedText = getSelectedTextFromWindowSelection(windowSelection);
-  console.log(`getSelectionFromCurrentWindowSelection() - selectedText ${JSON.stringify(selectedText)}`);
-  console.log(`getSelectionFromCurrentWindowSelection() - windowSelection.rangeCount ${windowSelection.rangeCount}`);
   let precedingText = getPrecedingTextFromWindowSelection(windowSelection);
-  console.log(`getSelectionFromCurrentWindowSelection() - precedingText ${JSON.stringify(precedingText)}`);
-
-  console.log(`getSelectionFromCurrentWindowSelection() - fallbackToPreviousWord ${fallbackToPreviousWord}`);
 
   if (fallbackToPreviousWord && (selectedText === ' ')) { // handle edge case of clicking near end of word
     const words = tokenize({ text: precedingText });
@@ -34,7 +28,6 @@ export const getSelectionFromCurrentWindowSelection = (entireText, fallbackToPre
           selectedText = lastWord;
           precedingText = precedingText.substr(0, pos);
           console.log(`getSelectionFromCurrentWindowSelection() - switching to last word, selectedText ${JSON.stringify(selectedText)}`);
-          console.log(`getSelectionFromCurrentWindowSelection() - precedingText ${JSON.stringify(precedingText)}`);
         }
       }
     }
@@ -70,10 +63,8 @@ export const getSelectedTextFromWindowSelection = (windowSelection) => windowSel
 export const getPrecedingTextFromWindowSelection = (windowSelection) => {
   let precedingText; // response
   // concatenate spans etc... to get the precedingText from the windowSelection
-  // const selectedText = getSelectedTextFromWindowSelection(windowSelection);
 
-  // do nothing since an empty space was selected
-  if (windowSelection.rangeCount) { // (selectedText !== '') {
+  if (windowSelection.rangeCount) {
     // get the text after the preceding selection and current span selection is in.
     const selectionRange = windowSelection.getRangeAt(0);
     // get the character index of what is selected in context of the span it is in.

--- a/src/VerseCheck/helpers/windowSelectionHelpers.js
+++ b/src/VerseCheck/helpers/windowSelectionHelpers.js
@@ -12,8 +12,9 @@ export const getSelectionFromCurrentWindowSelection = (entireText) => {
   console.log(`getSelectionFromCurrentWindowSelection() - windowSelection ${JSON.stringify(windowSelection)}`);
   const selectedText = getSelectedTextFromWindowSelection(windowSelection);
   console.log(`getSelectionFromCurrentWindowSelection() - selectedText ${JSON.stringify(selectedText)}`);
+  console.log(`getSelectionFromCurrentWindowSelection() - selectedText ${JSON.stringify(selectedText)}`);
   const prescedingText = getPrescedingTextFromWindowSelection(windowSelection);
-  console.log(`getSelectionFromCurrentWindowSelection() - prescedingText ${JSON.stringify(prescedingText)}`);
+  console.log(`getSelectionFromCurrentWindowSelection() - windowSelection.rangeCount ${windowSelection.rangeCount}`);
   // Some edge cases leave a weird selection remaining, let's clean up.
   selection = stringHelpers.generateSelection(selectedText, prescedingText, entireText);
   window.getSelection().empty();

--- a/src/VerseCheck/helpers/windowSelectionHelpers.js
+++ b/src/VerseCheck/helpers/windowSelectionHelpers.js
@@ -4,7 +4,7 @@ import * as stringHelpers from './stringHelpers';
 /**
  * @description - Gets the selection object from the currently selected text from the Web UI
  * @param {String} entireText - the text that the selection should be in, ie verseText
- * @param {Boolean} fallbackToPreviousWord - if true then we select previous word if selection is at end
+ * @param {Boolean} fallbackToPreviousWord - if true then we select previous word if selection is at end of word
  * @return {Object} - the selection object to be used
  * TODO: Find a way to test
  */

--- a/src/VerseCheck/helpers/windowSelectionHelpers.js
+++ b/src/VerseCheck/helpers/windowSelectionHelpers.js
@@ -1,3 +1,4 @@
+import { tokenize } from 'string-punctuation-tokenizer';
 import * as stringHelpers from './stringHelpers';
 
 /**
@@ -10,13 +11,32 @@ export const getSelectionFromCurrentWindowSelection = (entireText) => {
   let selection; // response
   const windowSelection = getCurrentWindowSelection();
   console.log(`getSelectionFromCurrentWindowSelection() - windowSelection ${JSON.stringify(windowSelection)}`);
-  const selectedText = getSelectedTextFromWindowSelection(windowSelection);
+  let selectedText = getSelectedTextFromWindowSelection(windowSelection);
   console.log(`getSelectionFromCurrentWindowSelection() - selectedText ${JSON.stringify(selectedText)}`);
   console.log(`getSelectionFromCurrentWindowSelection() - windowSelection.rangeCount ${windowSelection.rangeCount}`);
-  const prescedingText = getPrescedingTextFromWindowSelection(windowSelection);
-  console.log(`getSelectionFromCurrentWindowSelection() - prescedingText ${JSON.stringify(prescedingText)}`);
+  let precedingText = getPrecedingTextFromWindowSelection(windowSelection);
+  console.log(`getSelectionFromCurrentWindowSelection() - precedingText ${JSON.stringify(precedingText)}`);
+
+  if (selectedText === '') { // handle edge case of clicking near end of word
+    const words = tokenize({ text: precedingText });
+
+    if (words && words.length) {
+      const lastWord = words[words.length - 1];
+
+      if (lastWord) {
+        const pos = precedingText.lastIndexOf(lastWord);
+
+        if (pos && (pos + lastWord.length === precedingText.length)) { // if last word is at end of string
+          // use last word for selection
+          selectedText = lastWord;
+          precedingText = precedingText.substr(0, pos);
+        }
+      }
+    }
+  }
+
   // Some edge cases leave a weird selection remaining, let's clean up.
-  selection = stringHelpers.generateSelection(selectedText, prescedingText, entireText);
+  selection = stringHelpers.generateSelection(selectedText, precedingText, entireText);
   window.getSelection().empty();
   return selection;
 };
@@ -34,22 +54,22 @@ export const getCurrentWindowSelection = () => window.getSelection();
 */
 export const getSelectedTextFromWindowSelection = (windowSelection) => windowSelection.toString();
 /**
-* @description - Gets the prescedingText from the windowSelection
+* @description - Gets the precedingText from the windowSelection
 * @param {Object} windowSelection - a windowSelection object from inside a compatible element
-* @return {String} - the string of prescedingText
+* @return {String} - the string of precedingText
 * Implementation notes on why you can't just use the window.getSelection()
 * getSelection is limited by same innerText node, and does not include span siblings
 * indexOfTextSelection is broken by any other previous selection since it only knows its innerText node.
 * TODO: Find a way to test
 */
-export const getPrescedingTextFromWindowSelection = (windowSelection) => {
-  let prescedingText; // response
-  // concatenate spans etc... to get the prescedingText from the windowSelection
-  const selectedText = getSelectedTextFromWindowSelection(windowSelection);
+export const getPrecedingTextFromWindowSelection = (windowSelection) => {
+  let precedingText; // response
+  // concatenate spans etc... to get the precedingText from the windowSelection
+  // const selectedText = getSelectedTextFromWindowSelection(windowSelection);
 
   // do nothing since an empty space was selected
   if (windowSelection.rangeCount) { // (selectedText !== '') {
-    // get the text after the presceding selection and current span selection is in.
+    // get the text after the preceding selection and current span selection is in.
     const selectionRange = windowSelection.getRangeAt(0);
     // get the character index of what is selected in context of the span it is in.
     const selectionRangeStart = selectionRange.startOffset;
@@ -76,43 +96,43 @@ export const getPrescedingTextFromWindowSelection = (windowSelection) => {
 
     // check for element, as textContainer can but rarely be something other than #text, span or div
     if (element) {
-      prescedingText = getPrescedingTextFromElementAndSiblings(element, selectionRangeStart, windowSelection);
+      precedingText = getPrecedingTextFromElementAndSiblings(element, selectionRangeStart, windowSelection);
     }
   }
-  return prescedingText;
+  return precedingText;
 };
 /**
- * @description - gets the prescedingText from the element ending at the selectionRangeStart
+ * @description - gets the precedingText from the element ending at the selectionRangeStart
  * @param {Element} element - the html element that has text and siblings with text
  * @param {Int} selectionRangeStart - the character index of the start of the selection
- * @return {String} - the string of prescedingText
+ * @return {String} - the string of precedingText
  */
-export const getPrescedingTextFromElementAndSiblings = (element, selectionRangeStart, windowSelection) => {
-  let prescedingText; // response
-  const prescedingTextFromElementSiblings = getPrescedingTextFromElementSiblings(element, windowSelection);
-  const prescedingTextFromElement = getPrescedingTextFromElement(element, selectionRangeStart, windowSelection);
-  prescedingText = prescedingTextFromElementSiblings + prescedingTextFromElement;
-  return prescedingText;
+export const getPrecedingTextFromElementAndSiblings = (element, selectionRangeStart, windowSelection) => {
+  let precedingText; // response
+  const precedingTextFromElementSiblings = getPrecedingTextFromElementSiblings(element, windowSelection);
+  const precedingTextFromElement = getPrecedingTextFromElement(element, selectionRangeStart, windowSelection);
+  precedingText = precedingTextFromElementSiblings + precedingTextFromElement;
+  return precedingText;
 };
 /**
- * @description - gets the prescedingText from the element ending at the selectionRangeStart
+ * @description - gets the precedingText from the element ending at the selectionRangeStart
  * @param {Element} element - the html element that has text
  * @param {Int} selectionRangeStart - the character index of the start of the selection
- * @return {String} - the string of prescedingText
+ * @return {String} - the string of precedingText
  */
-export const getPrescedingTextFromElement = (element, selectionRangeStart) => {
-  let prescedingText; // response
+export const getPrecedingTextFromElement = (element, selectionRangeStart) => {
+  let precedingText; // response
   const text = element.textContent;
-  prescedingText = text.slice(0, selectionRangeStart);
-  return prescedingText;
+  precedingText = text.slice(0, selectionRangeStart);
+  return precedingText;
 };
 /**
- * @description - gets the prescedingText from the element siblings
+ * @description - gets the precedingText from the element siblings
  * @param {Element} element - the html element that has text and siblings with text
- * @return {String} - the string of prescedingText
+ * @return {String} - the string of precedingText
  */
-export const getPrescedingTextFromElementSiblings = (element, windowSelection) => {
-  let prescedingText = ''; // response
+export const getPrecedingTextFromElementSiblings = (element, windowSelection) => {
+  let precedingText = ''; // response
   // get the previous sibling to start the loop
   let previousSibling = element.previousElementSibling;
 
@@ -120,13 +140,13 @@ export const getPrescedingTextFromElementSiblings = (element, windowSelection) =
   while (previousSibling) {
     // just in case the previousSibling just happens to be a part of the selection
     if (windowSelection && !windowSelection.containsNode(previousSibling)) {
-      // prepend the spans innerText to the prescedingText
-      prescedingText = previousSibling.textContent + prescedingText;
+      // prepend the spans innerText to the precedingText
+      precedingText = previousSibling.textContent + precedingText;
     }
     // move to the previous span, if none, it ends the loop
     previousSibling = previousSibling.previousElementSibling;
   }
-  return prescedingText;
+  return precedingText;
 };
 
 /**

--- a/src/VerseCheck/helpers/windowSelectionHelpers.js
+++ b/src/VerseCheck/helpers/windowSelectionHelpers.js
@@ -9,8 +9,11 @@ import * as stringHelpers from './stringHelpers';
 export const getSelectionFromCurrentWindowSelection = (entireText) => {
   let selection; // response
   const windowSelection = getCurrentWindowSelection();
+  console.log(`getSelectionFromCurrentWindowSelection() - windowSelection ${JSON.stringify(windowSelection)}`);
   const selectedText = getSelectedTextFromWindowSelection(windowSelection);
+  console.log(`getSelectionFromCurrentWindowSelection() - selectedText ${JSON.stringify(selectedText)}`);
   const prescedingText = getPrescedingTextFromWindowSelection(windowSelection);
+  console.log(`getSelectionFromCurrentWindowSelection() - prescedingText ${JSON.stringify(prescedingText)}`);
   // Some edge cases leave a weird selection remaining, let's clean up.
   selection = stringHelpers.generateSelection(selectedText, prescedingText, entireText);
   window.getSelection().empty();

--- a/src/VerseCheck/helpers/windowSelectionHelpers.js
+++ b/src/VerseCheck/helpers/windowSelectionHelpers.js
@@ -48,7 +48,7 @@ export const getPrescedingTextFromWindowSelection = (windowSelection) => {
   const selectedText = getSelectedTextFromWindowSelection(windowSelection);
 
   // do nothing since an empty space was selected
-  if (selectedText !== '') {
+  if (windowSelection.rangeCount) { // (selectedText !== '') {
     // get the text after the presceding selection and current span selection is in.
     const selectionRange = windowSelection.getRangeAt(0);
     // get the character index of what is selected in context of the span it is in.


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- added detection of double-click from mouse events
- Fix for double-click near end of word in checking tools
- fixed typo `presceding` to `preceding`

#### Please include detailed Test instructions for your pull request:
- use build attached to: https://github.com/unfoldingWord/translationCore/pull/7039
- see issue https://github.com/unfoldingword/translationcore/issues/7024 - should be able to double-click near end of word and select it.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/281)
<!-- Reviewable:end -->
