### PR TITLE
Bugfix 7043/fix verse title right padding with RTL languages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/src/VerseCheck/DefaultArea/index.js
+++ b/src/VerseCheck/DefaultArea/index.js
@@ -99,6 +99,7 @@ class DefaultArea extends React.Component {
       style.justifyContent = 'right';
       style.width = '100%';
       style.direction = 'rtl';
+      style.paddingRight = '15px';
     }
 
     return (

--- a/src/VerseCheck/SelectionArea/index.js
+++ b/src/VerseCheck/SelectionArea/index.js
@@ -54,6 +54,7 @@ const SelectionArea = ({
     style.justifyContent = 'right';
     style.width = '100%';
     style.direction = 'rtl';
+    style.paddingRight = '15px';
   }
 
   return (


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix verse title right padding when rtl to match text area in default and selection mode

#### Please include detailed Test instructions for your pull request:
- verse title right padding when rtl should match text area in default mode and selection mode

![Screen Shot 2020-07-08 at 4 54 47 PM copy](https://user-images.githubusercontent.com/14238574/86969592-07b93c00-c13c-11ea-8cc2-b613a98f6744.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/282)
<!-- Reviewable:end -->
