### PR TITLE
Feature 7038/Make verse edit fonts resizable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/src/ScripturePane/ExpandedScripturePaneModal/ChapterView/index.js
+++ b/src/ScripturePane/ExpandedScripturePaneModal/ChapterView/index.js
@@ -90,7 +90,7 @@ class ChapterView extends Component {
     const openEditor = editVerse !== null;
     let verseTitle = '';
     let verseText = '';
-    let targetLanguageFontSize = '100%';
+    let fontSizePercent = 100; // default font size
     const direction = projectManifest.target_language && projectManifest.target_language.direction || 'ltr';
 
     if (openEditor) {
@@ -107,7 +107,7 @@ class ChapterView extends Component {
       const targetConfig = currentPaneSettings.find(pane => (pane.languageId === 'targetLanguage'));
 
       if (targetConfig) {
-        targetLanguageFontSize = `${targetConfig.fontSize}%`;
+        fontSizePercent = targetConfig.fontSize;
       }
     }
 
@@ -124,7 +124,7 @@ class ChapterView extends Component {
           onSubmit={handleEditorSubmit}
           onCancel={handleEditorCancel}
           targetLanguageFont={targetLanguageFont}
-          targetLanguageFontSize={targetLanguageFontSize}
+          targetLanguageFontSize={`${fontSizePercent}%`}
           direction={direction}
         />
       </div>

--- a/src/ScripturePane/ExpandedScripturePaneModal/ChapterView/index.js
+++ b/src/ScripturePane/ExpandedScripturePaneModal/ChapterView/index.js
@@ -90,6 +90,7 @@ class ChapterView extends Component {
     const openEditor = editVerse !== null;
     let verseTitle = '';
     let verseText = '';
+    let targetLanguageFontSize = '100%';
     const direction = projectManifest.target_language && projectManifest.target_language.direction || 'ltr';
 
     if (openEditor) {
@@ -103,6 +104,11 @@ class ChapterView extends Component {
       const refStr = getReferenceStr(editVerse.chapter, editVerse.verse);
       verseTitle = getTitleStr(bookName, refStr, direction);
       verseText = editVerse.verseText;
+      const targetConfig = currentPaneSettings.find(pane => (pane.languageId === 'targetLanguage'));
+
+      if (targetConfig) {
+        targetLanguageFontSize = `${targetConfig.fontSize}%`;
+      }
     }
 
     return (
@@ -118,6 +124,7 @@ class ChapterView extends Component {
           onSubmit={handleEditorSubmit}
           onCancel={handleEditorCancel}
           targetLanguageFont={targetLanguageFont}
+          targetLanguageFontSize={targetLanguageFontSize}
           direction={direction}
         />
       </div>

--- a/src/VerseCheck/CheckArea/index.js
+++ b/src/VerseCheck/CheckArea/index.js
@@ -43,6 +43,8 @@ const CheckArea = ({
 
   switch (mode) {
   case 'edit':
+    var fontSize = (toolsSettings['CheckArea'] && toolsSettings['CheckArea'].fontSize) || 100;
+
     modeArea = (
       <EditVerseArea
         tags={tags}
@@ -54,6 +56,7 @@ const CheckArea = ({
         languageDirection={languageDirection}
         translate={translate}
         targetLanguageFont={targetLanguageFont}
+        targetLanguageFontSize={`${fontSize}%`}
       />
     );
     break;

--- a/src/VerseCheck/EditVerseArea/index.js
+++ b/src/VerseCheck/EditVerseArea/index.js
@@ -106,23 +106,25 @@ const EditVerseArea = ({
         {translate('edit_verse')}
       </div>
       <FormGroup style={{
-        flex: 'auto', display: 'flex', flexDirection: 'column', marginBottom: '5px', fontSize: targetLanguageFontSize,
+        flex: 'auto', display: 'flex', flexDirection: 'column', marginBottom: '5px',
       }} controlId='formControlsTextarea'>
-        <FormControl
-          autoFocus
-          onFocus={moveCursorToEnd}
-          componentClass='textarea'
-          type='text'
-          defaultValue={verseText}
-          className={fontClass}
-          style={{
-            flex: 'auto',
-            minHeight: '110px',
-            direction: languageDirection,
-          }}
-          onBlur={handleEditVerse}
-          onInput={checkIfVerseChanged}
-        />
+        <div style={{ fontSize: targetLanguageFontSize }}>
+          <FormControl
+            autoFocus
+            onFocus={moveCursorToEnd}
+            componentClass='textarea'
+            type='text'
+            defaultValue={verseText}
+            className={fontClass}
+            style={{
+              flex: 'auto',
+              minHeight: '110px',
+              direction: languageDirection,
+            }}
+            onBlur={handleEditVerse}
+            onInput={checkIfVerseChanged}
+          />
+        </div>
         <div style={{
           flex: '0 0 65px', marginTop: '5px', fontSize: '0.9em',
         }}>

--- a/src/VerseCheck/EditVerseArea/index.js
+++ b/src/VerseCheck/EditVerseArea/index.js
@@ -35,6 +35,7 @@ const EditVerseArea = ({
   handleEditVerse,
   checkIfVerseChanged,
   targetLanguageFont,
+  targetLanguageFontSize,
 }) => {
   const tagList1 = [
     ['spelling', translate('spelling')],
@@ -105,7 +106,7 @@ const EditVerseArea = ({
         {translate('edit_verse')}
       </div>
       <FormGroup style={{
-        flex: 'auto', display: 'flex', flexDirection: 'column', marginBottom: '5px',
+        flex: 'auto', display: 'flex', flexDirection: 'column', marginBottom: '5px', fontSize: targetLanguageFontSize,
       }} controlId='formControlsTextarea'>
         <FormControl
           autoFocus
@@ -156,6 +157,7 @@ EditVerseArea.propTypes = {
   handleEditVerse: PropTypes.func.isRequired,
   checkIfVerseChanged: PropTypes.func.isRequired,
   targetLanguageFont: PropTypes.string,
+  targetLanguageFontSize: PropTypes.string.isRequired,
 };
 
 export default withStyles(styles)(EditVerseArea);

--- a/src/VerseCheck/EditVerseArea/index.js
+++ b/src/VerseCheck/EditVerseArea/index.js
@@ -108,7 +108,7 @@ const EditVerseArea = ({
       <FormGroup style={{
         flex: 'auto', display: 'flex', flexDirection: 'column', marginBottom: '5px',
       }} controlId='formControlsTextarea'>
-        <div style={{ fontSize: targetLanguageFontSize }}>
+        <div style={{ fontSize: targetLanguageFontSize }}> {/*apply desired font size multiplier before font class styling*/}
           <FormControl
             autoFocus
             onFocus={moveCursorToEnd}

--- a/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
+++ b/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
@@ -190,6 +190,7 @@ exports[`VerseCheck component: Integrated View test - edit mode 1`] = `
                   }
                 }
               >
+                 
                 <textarea
                   autoFocus={true}
                   className="form-control"

--- a/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
+++ b/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
@@ -183,23 +183,31 @@ exports[`VerseCheck component: Integrated View test - edit mode 1`] = `
                 }
               }
             >
-              <textarea
-                autoFocus={true}
-                className="form-control"
-                defaultValue="Kono ewe, oambe ziyenderera ne ntaero zisepahara.
-\\\\s5
-"
-                id="formControlsTextarea"
-                onFocus={[Function]}
+              <div
                 style={
                   Object {
-                    "direction": "ltr",
-                    "flex": "auto",
-                    "minHeight": "110px",
+                    "fontSize": "100%",
                   }
                 }
-                type="text"
-              />
+              >
+                <textarea
+                  autoFocus={true}
+                  className="form-control"
+                  defaultValue="Kono ewe, oambe ziyenderera ne ntaero zisepahara.
+\\\\s5
+"
+                  id="formControlsTextarea"
+                  onFocus={[Function]}
+                  style={
+                    Object {
+                      "direction": "ltr",
+                      "flex": "auto",
+                      "minHeight": "110px",
+                    }
+                  }
+                  type="text"
+                />
+              </div>
               <div
                 style={
                   Object {

--- a/src/VerseEditor/EditScreen.js
+++ b/src/VerseEditor/EditScreen.js
@@ -39,7 +39,7 @@ class EditScreen extends React.Component {
       textAlign: isLTR(direction) ? 'left' : 'right',
     };
     return (
-      <div fontSize={targetLanguageFontSize}>
+      <div style={{ fontSize: targetLanguageFontSize }}>
         <textarea
           id="verse-editor-field"
           rows={rows}

--- a/src/VerseEditor/EditScreen.js
+++ b/src/VerseEditor/EditScreen.js
@@ -39,7 +39,7 @@ class EditScreen extends React.Component {
       textAlign: isLTR(direction) ? 'left' : 'right',
     };
     return (
-      <div style={{ fontSize: targetLanguageFontSize }}>
+      <div style={{ fontSize: targetLanguageFontSize }}> {/*apply desired font size multiplier before font class styling*/}
         <textarea
           id="verse-editor-field"
           rows={rows}

--- a/src/VerseEditor/EditScreen.js
+++ b/src/VerseEditor/EditScreen.js
@@ -30,6 +30,7 @@ class EditScreen extends React.Component {
       style,
       verseText,
       targetLanguageFontClassName,
+      targetLanguageFontSize,
       direction,
     } = this.props;
     const className = targetLanguageFontClassName ? `edit-screen ${targetLanguageFontClassName}` : 'edit-screen';
@@ -38,16 +39,18 @@ class EditScreen extends React.Component {
       textAlign: isLTR(direction) ? 'left' : 'right',
     };
     return (
-      <textarea
-        id="verse-editor-field"
-        rows={rows}
-        className={className}
-        autoFocus={true}
-        onFocus={moveCursorToEnd}
-        onChange={this._handleChange}
-        value={verseText}
-        style={style_}
-      />
+      <div fontSize={targetLanguageFontSize}>
+        <textarea
+          id="verse-editor-field"
+          rows={rows}
+          className={className}
+          autoFocus={true}
+          onFocus={moveCursorToEnd}
+          onChange={this._handleChange}
+          value={verseText}
+          style={style_}
+        />
+      </div>
     );
   }
 }
@@ -59,12 +62,14 @@ EditScreen.propTypes = {
   verseText: PropTypes.string.isRequired,
   direction: PropTypes.string.isRequired,
   targetLanguageFontClassName: PropTypes.string,
+  targetLanguageFontSize: PropTypes.string,
 };
 
 EditScreen.defaultProps = {
   rows: 4,
   style: {},
   direction: 'ltr',
+  targetLanguageFontSize: '100%',
 };
 
 export default EditScreen;

--- a/src/VerseEditor/VerseEditor.js
+++ b/src/VerseEditor/VerseEditor.js
@@ -118,6 +118,7 @@ class VerseEditor extends React.Component {
       verseTitle,
       targetLanguage,
       targetLanguageFont,
+      targetLanguageFontSize,
       direction,
     } = this.props;
     const {
@@ -135,10 +136,15 @@ class VerseEditor extends React.Component {
     );
     const rows = 9 + (!targetLanguage ? 1 : 0); // make taller if no language label
     const headingStyle = { ...styles.editHeading };
+    const editorStyles = { ...styles.editor };
 
     if (!isLTR(direction)) { // if rtl, right justify
       headingStyle.textAlign = 'right';
       headingStyle.paddingRight = '6px';
+    }
+
+    if (targetLanguageFontSize) {
+      editorStyles.fontSize = targetLanguageFontSize;
     }
 
     return (
@@ -160,7 +166,7 @@ class VerseEditor extends React.Component {
             <EditScreen
               rows={rows}
               verseText={text}
-              style={styles.editor}
+              style={editorStyles}
               onChange={this._handleVerseChange}
               targetLanguageFontClassName={targetLanguageFontClassName}
               direction={direction}
@@ -211,12 +217,14 @@ VerseEditor.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   targetLanguage: PropTypes.string.isRequired,
   targetLanguageFont: PropTypes.string,
+  targetLanguageFontSize: PropTypes.string,
   direction: PropTypes.string.isRequired,
 };
 
 VerseEditor.defaultProps = {
   targetLanguage: '',
   direction: 'ltr',
+  targetLanguageFontSize: '150%',
 };
 
 export default VerseEditor;

--- a/src/VerseEditor/VerseEditor.js
+++ b/src/VerseEditor/VerseEditor.js
@@ -136,15 +136,10 @@ class VerseEditor extends React.Component {
     );
     const rows = 9 + (!targetLanguage ? 1 : 0); // make taller if no language label
     const headingStyle = { ...styles.editHeading };
-    const editorStyles = { ...styles.editor };
 
     if (!isLTR(direction)) { // if rtl, right justify
       headingStyle.textAlign = 'right';
       headingStyle.paddingRight = '6px';
-    }
-
-    if (targetLanguageFontSize) {
-      editorStyles.fontSize = targetLanguageFontSize;
     }
 
     return (
@@ -166,9 +161,10 @@ class VerseEditor extends React.Component {
             <EditScreen
               rows={rows}
               verseText={text}
-              style={editorStyles}
+              style={styles.editor}
               onChange={this._handleVerseChange}
               targetLanguageFontClassName={targetLanguageFontClassName}
+              targetLanguageFontSize={targetLanguageFontSize}
               direction={direction}
             />
           </div>

--- a/src/VerseEditor/VerseEditor.js
+++ b/src/VerseEditor/VerseEditor.js
@@ -220,7 +220,7 @@ VerseEditor.propTypes = {
 VerseEditor.defaultProps = {
   targetLanguage: '',
   direction: 'ltr',
-  targetLanguageFontSize: '150%',
+  targetLanguageFontSize: '100%',
 };
 
 export default VerseEditor;

--- a/src/VerseEditor/__tests__/__snapshots__/VerseEdit.test.js.snap
+++ b/src/VerseEditor/__tests__/__snapshots__/VerseEdit.test.js.snap
@@ -56,6 +56,7 @@ exports[`VerseEditor component: should render 1`] = `
           }
         }
         targetLanguageFontClassName=""
+        targetLanguageFontSize="100%"
         verseText="Dummy Text"
       />
     </div>


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- added font size to verse edit dialog in verseCheck and in verseEditor (used by EnhancedScripturePane and called by wA)

#### Please include detailed Test instructions for your pull request:
- use build attached to https://github.com/unfoldingWord/translationCore/pull/7050
- in wA, text size in verse editor should match text size in alignment grid area:
![Screen Shot 2020-07-09 at 3 08 36 PM copy](https://user-images.githubusercontent.com/14238574/87080943-8a063680-c1f6-11ea-9741-e96861d67f37.png)

- in enhanced scripture pane, text size  in verse editor should match text size in target language pane:
![Screen Shot 2020-07-09 at 3 09 14 PM copy](https://user-images.githubusercontent.com/14238574/87081136-cdf93b80-c1f6-11ea-862b-06ecd08fafe0.png)

- in tW and tN, text size in verse editor should match text size in selection area:
![Screen Shot 2020-07-09 at 3 09 55 PM copy](https://user-images.githubusercontent.com/14238574/87081292-16185e00-c1f7-11ea-880f-964922849838.png)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/283)
<!-- Reviewable:end -->
