### PR TITLE
Bugfix 7041/Fix quotes for selections in instructions area of verse check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/src/VerseCheck/CheckArea/index.js
+++ b/src/VerseCheck/CheckArea/index.js
@@ -102,7 +102,7 @@ const CheckArea = ({
           invalidated={invalidated}
           nothingToSelect={nothingToSelect}
           targetLanguageFont={targetLanguageFont}
-          languageDirection={targetLanguageDirection}
+          targetLanguageDirection={targetLanguageDirection}
         />
       </div>
     );

--- a/src/VerseCheck/CheckArea/index.js
+++ b/src/VerseCheck/CheckArea/index.js
@@ -83,6 +83,7 @@ const CheckArea = ({
           translate={translate}
           invalidated={invalidated}
           targetLanguageFont={targetLanguageFont}
+          languageDirection={languageDirection}
         />
       </div>);
     break;
@@ -101,6 +102,7 @@ const CheckArea = ({
           invalidated={invalidated}
           nothingToSelect={nothingToSelect}
           targetLanguageFont={targetLanguageFont}
+          languageDirection={languageDirection}
         />
       </div>
     );

--- a/src/VerseCheck/CheckArea/index.js
+++ b/src/VerseCheck/CheckArea/index.js
@@ -39,7 +39,7 @@ const CheckArea = ({
   changeSelectionsInLocalState,
 }) => {
   let modeArea;
-  const { direction: languageDirection = 'ltr' } = targetLanguageDetails || {};
+  const { direction: targetLanguageDirection = 'ltr' } = targetLanguageDetails || {};
 
   switch (mode) {
   case 'edit':
@@ -53,7 +53,7 @@ const CheckArea = ({
         handleTagsCheckbox={handleTagsCheckbox}
         handleEditVerse={handleEditVerse}
         checkIfVerseChanged={checkIfVerseChanged}
-        languageDirection={languageDirection}
+        languageDirection={targetLanguageDirection}
         translate={translate}
         targetLanguageFont={targetLanguageFont}
         targetLanguageFontSize={`${fontSize}%`}
@@ -83,7 +83,7 @@ const CheckArea = ({
           translate={translate}
           invalidated={invalidated}
           targetLanguageFont={targetLanguageFont}
-          languageDirection={languageDirection}
+          targetLanguageDirection={targetLanguageDirection}
         />
       </div>);
     break;
@@ -102,7 +102,7 @@ const CheckArea = ({
           invalidated={invalidated}
           nothingToSelect={nothingToSelect}
           targetLanguageFont={targetLanguageFont}
-          languageDirection={languageDirection}
+          languageDirection={targetLanguageDirection}
         />
       </div>
     );

--- a/src/VerseCheck/InstructionsArea/index.js
+++ b/src/VerseCheck/InstructionsArea/index.js
@@ -38,7 +38,7 @@ const InstructionsArea = ({
   nothingToSelect,
   targetLanguageFont,
   dontShowTranslation,
-  languageDirection,
+  targetLanguageDirection,
 }) => {
   if (!verseText) {
     return (
@@ -96,7 +96,7 @@ const InstructionsArea = ({
           selections={selections}
           verseText={verseText}
           targetLanguageFont={targetLanguageFont}
-          languageDirection={languageDirection}
+          languageDirection={targetLanguageDirection}
         />
       </span>
     </div>
@@ -113,9 +113,9 @@ InstructionsArea.propTypes = {
   invalidated: PropTypes.bool,
   nothingToSelect: PropTypes.bool,
   targetLanguageFont: PropTypes.string,
-  languageDirection: PropTypes.string,
+  targetLanguageDirection: PropTypes.string,
 };
 
-InstructionsArea.defaultProps = { languageDirection: 'ltr' };
+InstructionsArea.defaultProps = { targetLanguageDirection: 'ltr' };
 
 export default InstructionsArea;

--- a/src/VerseCheck/InstructionsArea/index.js
+++ b/src/VerseCheck/InstructionsArea/index.js
@@ -38,6 +38,7 @@ const InstructionsArea = ({
   nothingToSelect,
   targetLanguageFont,
   dontShowTranslation,
+  languageDirection,
 }) => {
   if (!verseText) {
     return (
@@ -95,6 +96,7 @@ const InstructionsArea = ({
           selections={selections}
           verseText={verseText}
           targetLanguageFont={targetLanguageFont}
+          languageDirection={languageDirection}
         />
       </span>
     </div>
@@ -111,6 +113,9 @@ InstructionsArea.propTypes = {
   invalidated: PropTypes.bool,
   nothingToSelect: PropTypes.bool,
   targetLanguageFont: PropTypes.string,
+  languageDirection: PropTypes.string,
 };
+
+InstructionsArea.defaultProps = { languageDirection: 'ltr' };
 
 export default InstructionsArea;

--- a/src/VerseCheck/InstructionsAreaTextSelection/index.js
+++ b/src/VerseCheck/InstructionsAreaTextSelection/index.js
@@ -40,19 +40,19 @@ const InstructionsAreaTextSelection = ({
 
   if (windowSelectionHelpers.shouldRenderEllipsis(selections, verseText)) {
     return (
-      <strong style={{ color: 'var(--accent-color)', direction: languageDirection }}>
+      <div style={{ color: 'var(--accent-color)', direction: languageDirection }}>
         <span className={fontClass}>{selections[0].text.trim()}</span>
         <strong className={fontClass} style={{ color: 'var(--accent-color)' }}>
           {` ${ELLIPSIS} `}
         </strong>
         <span className={fontClass}>{selections[selections.length - 1].text.trim()}</span>
-      </strong>
+      </div>
     );
   } else {
     return (
-      <strong style={{ color: 'var(--accent-color)', direction: languageDirection }}>
+      <div style={{ color: 'var(--accent-color)', direction: languageDirection }}>
         {getSelectionSpans(selections, targetLanguageFont)}
-      </strong>
+      </div>
     );
   }
 };

--- a/src/VerseCheck/InstructionsAreaTextSelection/index.js
+++ b/src/VerseCheck/InstructionsAreaTextSelection/index.js
@@ -34,24 +34,25 @@ const InstructionsAreaTextSelection = ({
   verseText,
   selections,
   targetLanguageFont,
+  languageDirection,
 }) => {
   const fontClass = getFontClassName(targetLanguageFont);
 
   if (windowSelectionHelpers.shouldRenderEllipsis(selections, verseText)) {
     return (
-      <SelectedText>
+      <strong style={{ color: 'var(--accent-color)', direction: languageDirection }}>
         <span className={fontClass}>{selections[0].text.trim()}</span>
         <strong className={fontClass} style={{ color: 'var(--accent-color)' }}>
           {` ${ELLIPSIS} `}
         </strong>
         <span className={fontClass}>{selections[selections.length - 1].text.trim()}</span>
-      </SelectedText>
+      </strong>
     );
   } else {
     return (
-      <SelectedText>
+      <strong style={{ color: 'var(--accent-color)', direction: languageDirection }}>
         {getSelectionSpans(selections, targetLanguageFont)}
-      </SelectedText>
+      </strong>
     );
   }
 };
@@ -60,6 +61,9 @@ InstructionsAreaTextSelection.propTypes = {
   selections: PropTypes.array.isRequired,
   verseText: PropTypes.string.isRequired,
   targetLanguageFont: PropTypes.string,
+  languageDirection: PropTypes.string,
 };
+
+InstructionsAreaTextSelection.defaultProps = { languageDirection: 'ltr' };
 
 export default InstructionsAreaTextSelection;


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Fix quotes for selections in instructions area of verse check

#### Please include detailed Test instructions for your pull request:
- use tC branch bugfix-mcleanb-7041 for testing
- this will fix the problem with quotes in the first example (ar_nav_oba_book 2.zip) in issue https://github.com/unfoldingword/translationcore/issues/7041
- note that the second issue is not fixable since they selected a character that is supposed to be joined to character before it.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/285)
<!-- Reviewable:end -->
