### PR TITLE
Bugfix 7038/Fix font resizing in tW & tN verse edit boxes for default font

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/src/VerseCheck/EditVerseArea/index.js
+++ b/src/VerseCheck/EditVerseArea/index.js
@@ -97,7 +97,7 @@ const EditVerseArea = ({
     />,
   );
   const checkBoxText = isVerseChanged ? translate('next_change_reason') : translate('first_make_change');
-  const fontClass = getFontClassName(targetLanguageFont) || 'default-text'; // TRICKY defaulting to the 'default-text' here class prevents 'form-control' class from resetting font-size to 14px
+  const fontClass = getFontClassName(targetLanguageFont) || 'default-text'; // TRICKY defaulting to the 'default-text' class prevents 'form-control' class from resetting font-size to 14px
 
   return (
     <div className='edit-area'>

--- a/src/VerseCheck/EditVerseArea/index.js
+++ b/src/VerseCheck/EditVerseArea/index.js
@@ -97,7 +97,7 @@ const EditVerseArea = ({
     />,
   );
   const checkBoxText = isVerseChanged ? translate('next_change_reason') : translate('first_make_change');
-  const fontClass = getFontClassName(targetLanguageFont);
+  const fontClass = getFontClassName(targetLanguageFont) || 'default-text';
 
   return (
     <div className='edit-area'>

--- a/src/VerseCheck/EditVerseArea/index.js
+++ b/src/VerseCheck/EditVerseArea/index.js
@@ -97,7 +97,7 @@ const EditVerseArea = ({
     />,
   );
   const checkBoxText = isVerseChanged ? translate('next_change_reason') : translate('first_make_change');
-  const fontClass = getFontClassName(targetLanguageFont) || 'default-text';
+  const fontClass = getFontClassName(targetLanguageFont) || 'default-text'; // TRICKY defaulting to the 'default-text' here class prevents 'form-control' class from resetting font-size to 14px
 
   return (
     <div className='edit-area'>

--- a/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
+++ b/src/VerseCheck/__tests__/__snapshots__/ViewCheck.test.js.snap
@@ -193,7 +193,7 @@ exports[`VerseCheck component: Integrated View test - edit mode 1`] = `
                  
                 <textarea
                   autoFocus={true}
-                  className="form-control"
+                  className="default-text form-control"
                   defaultValue="Kono ewe, oambe ziyenderera ne ntaero zisepahara.
 \\\\s5
 "


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- for tN & tW, fixed font sizing in EditVerseArea for default font

#### Please include detailed Test instructions for your pull request:
- use tC branch `bugfix-mcleanb-7038` for testing
- in tN & tW: make sure target font is default. Click edit verse and text size should match size in selection/review area.  Drag font size slider up and down - should see font size in edit area changing with slider.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/286)
<!-- Reviewable:end -->
