### PR TITLE
Bugfix 7081/Fix order of punctuation in SP edit boxes for RTL languages.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-ui-toolkit",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "React components used to develop tools for the desktop app translationCore",
   "main": "lib/index.js",
   "display": "library",

--- a/src/VerseEditor/EditScreen.js
+++ b/src/VerseEditor/EditScreen.js
@@ -37,6 +37,7 @@ class EditScreen extends React.Component {
     const style_ = {
       ...style,
       textAlign: isLTR(direction) ? 'left' : 'right',
+      direction,
     };
     return (
       <div style={{ fontSize: targetLanguageFontSize }}> {/*apply desired font size multiplier before font class styling*/}


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- add direction to edit screen in scripture pane.

#### Please include detailed Test instructions for your pull request:
- test with build attached to https://github.com/unfoldingWord/translationCore/pull/7082
- open an arabic project in tN or tW.  Open expanded scripture pane.  Click to edit any verse that has punctuation at the end of verse, and should see punctuation in the verse editor in same order as shown in expanded scripture pane.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-ui-toolkit/295)
<!-- Reviewable:end -->
